### PR TITLE
Keyterm extraction using single-document based algos

### DIFF
--- a/event_extraction/keywords_single.py
+++ b/event_extraction/keywords_single.py
@@ -1,0 +1,298 @@
+import spacy
+import csv
+import string 
+import pandas as pd
+import re
+import sys
+import string
+import traceback
+import datetime
+from collections import Counter
+import yake
+import spacy
+import pke
+import nltk
+from tqdm import tqdm
+from multi_rake import Rake
+import textacy
+from textacy.extract import keyterms
+from textacy import preprocessing as textacy_preprocessing
+from keybert import KeyBERT
+import pandas as pd
+from pandas.core.common import flatten
+import spacy
+from somajo import SoMaJo
+from joblib import Parallel, delayed
+
+
+spacy_languages = {"en": "en_core_web_trf"}
+somajo_tokenizer = SoMaJo("en_PTB", split_sentences=False)
+
+
+def analyse(file):
+
+    print("Start time: ", str(datetime.datetime.now()))
+
+
+    def somajo_remove_url(text):
+        """
+        A customized function to remove e-mails which have whitespaces
+        and URLs which were apparently not cleaned from the corpus.
+        """
+        out = []
+        text_as_list = list()
+        text_as_list.append(text)
+        tokenized_text = somajo_tokenizer.tokenize_text(text_as_list)
+        for dummy_tokenized_text in tokenized_text:
+            # return([detokenize(bla) for bla in tokenized_text][0])
+            for token in dummy_tokenized_text:
+                if token.token_class == "URL":
+                    out.append("-URL-")
+                elif token.original_spelling is not None:
+                    out.append(token.original_spelling)
+                else:
+                    out.append(token.text)
+                if token.space_after:
+                    out.append(" ")
+        return "".join(out)
+
+
+    def text_preprocessing(text):
+        text = textacy_preprocessing.normalize.hyphenated_words(text)
+        text = textacy_preprocessing.normalize.whitespace(text)
+        text = textacy_preprocessing.replace.emails(text, "-Email-")
+        text = re.sub(r"[a-zA-Z0-9_.+-]+ @ [ a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+", " -Email- ", text)
+        text = textacy_preprocessing.replace.urls(text, "-URL-")
+        text = somajo_remove_url(text)
+        text = re.sub(" +", " ", "".join(x if x.isprintable() or x in string.whitespace else " " for x in text))
+        return text
+
+
+    def spacy_lemmatizer_with_whitespace(docs, language):
+        lemmatized_docs = []
+        nlp = spacy.load(spacy_languages[language])
+        for doc in nlp.pipe(tqdm(docs, total=len(docs), unit="doc", desc="Spacy lemmatizer"), n_process=1):
+            lemmatized_docs.append("".join([token.lemma_ + token.whitespace_ for token in doc]))
+        return lemmatized_docs
+
+
+    # def pke_textrank(text, language):
+    #     extractor = pke.unsupervised.TextRank()
+    #     try:
+    #         extractor.load_document(input=text, language=language)
+    #         extractor.candidate_selection()
+    #         extractor.candidate_weighting(pos={'NOUN', 'PROPN', 'VERB'})
+    #         keyphrases = extractor.get_n_best(n=20)
+    #         list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+    #     except:
+    #         tqdm.write(traceback.format_exc())
+    #         sys.exit()
+    #     return list_of_keyphrases
+
+
+    # def pke_singlerank(text, language):
+    #     extractor = pke.unsupervised.SingleRank()
+    #     try:
+    #         extractor.load_document(input=text, language=language)
+    #         extractor.candidate_selection(pos={'NOUN', 'PROPN', 'VERB'})
+    #         extractor.candidate_weighting(pos={'NOUN', 'PROPN', 'VERB'})
+    #         keyphrases = extractor.get_n_best(n=20)
+    #         list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+    #     except:
+    #         tqdm.write(traceback.format_exc())
+    #         sys.exit()
+    #     return list_of_keyphrases
+
+
+    # def pke_positionrank(text, language):
+    #     extractor = pke.unsupervised.PositionRank()
+    #     try:
+    #         extractor.load_document(input=text, language=language)
+    #         extractor.candidate_selection(grammar="NP: {<NOUN|PROPN>+}")
+    #         extractor.candidate_weighting(pos={'NOUN', 'PROPN', 'VERB'})
+    #         keyphrases = extractor.get_n_best(n=20)
+    #         list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+    #     except:
+    #         tqdm.write(traceback.format_exc())
+    #         sys.exit()
+    #     return list_of_keyphrases
+
+
+    # def pke_topicrank(text, language):
+    #     extractor = pke.unsupervised.TopicRank()
+    #     try:
+    #         extractor.load_document(input=text, language=language)
+    #         extractor.candidate_selection()
+    #         extractor.candidate_weighting()
+    #         keyphrases = extractor.get_n_best(n=20)
+    #         list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+    #     except:
+    #         tqdm.write(traceback.format_exc())
+    #         sys.exit()
+    #     return list_of_keyphrases
+
+
+    def pke_multipartiterank(text, language):
+        extractor = pke.unsupervised.MultipartiteRank()
+        try:
+            extractor.load_document(input=text, language=language)
+            extractor.candidate_selection(pos={'NOUN', 'PROPN', 'VERB'})
+            extractor.candidate_weighting()
+            keyphrases = extractor.get_n_best(n=20)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def textacy_textrank(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.textrank(doc, normalize="lemma", topn=20, include_pos=pos, window_size=2, edge_weighting="binary", position_bias=False)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def textacy_singlerank(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.textrank(doc, normalize="lemma", topn=20, include_pos=pos, window_size=10, edge_weighting="count", position_bias=False)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def textacy_positionrank(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.textrank(doc, normalize="lemma", topn=20, include_pos=pos, window_size=10, edge_weighting="count", position_bias=True)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def textacy_yake(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.yake(doc, ngrams=1, normalize="lemma", topn=20, include_pos=pos)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            print(text)
+            list_of_keyphrases = []
+        return list_of_keyphrases
+
+
+    def textacy_scake(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.scake(doc, normalize="lemma", topn=20, include_pos=pos)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def textacy_sgrank(text, language, pos):
+        try:
+            doc = textacy.make_spacy_doc(text, lang=spacy_languages[language])
+            keyphrases = keyterms.sgrank(doc, ngrams=1, normalize="lemma", topn=20, include_pos=pos)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            list_of_keyphrases = []
+        return list_of_keyphrases
+
+
+    def keybert(text, language):
+        try:
+            if language == "en":
+                kw_model = KeyBERT(model="paraphrase-mpnet-base-v2")
+            else:
+                kw_model = KeyBERT(model="paraphrase-multilingual-mpnet-base-v2")
+            keyphrases = kw_model.extract_keywords(text, keyphrase_ngram_range=(1, 1), top_n=20)
+            list_of_keyphrases = [keyphrase for keyphrase, score in keyphrases]
+        except:
+            tqdm.write(traceback.format_exc())
+            sys.exit()
+        return list_of_keyphrases
+
+
+    def postprocessing(list_of_lists_of_keywords, name, pos=None):
+        list_of_lists_of_keywords = [keyword.lower() for list_of_keywords in list_of_lists_of_keywords for keyword in list_of_keywords]
+        list_of_freq_keywords = nltk.FreqDist(flatten(list_of_lists_of_keywords)).most_common()
+        if pos:
+            df_keywords = pd.DataFrame(list_of_freq_keywords, columns=[name + "_" + pos, name + "_" + pos + "_" + "Freq"])
+        else:
+            df_keywords = pd.DataFrame(list_of_freq_keywords, columns=[name, name + "_" + "Freq"])
+        print(df_keywords.head())
+        return df_keywords
+
+
+    ### Entry point ###
+
+    keyphrase_extractors = {
+        "KeyBert": keybert,
+        "TextRank": textacy_textrank,
+        "SingleRank": textacy_singlerank,
+        "PositionRank": textacy_positionrank,
+        "MultipartiteRank": pke_multipartiterank,
+        "Yake": textacy_yake,
+        "sCAKE": textacy_scake,
+        "SGRank": textacy_sgrank
+    }
+
+    # Depending whether the library does lemmatization or not by itself, the appropriate list is passed to the function
+    groups_of_algorithms = {"misc":['MultiRake', "KeyBert"],
+            "pke":['TopicRank', 'MultipartiteRank'],
+            "textacy":['TextRank', 'SingleRank', 'PositionRank', "Yake", "sCAKE", "SGRank"]}
+
+    language = "en"
+    include_pos = ['NOUN', "PROPN", "VERB"]
+
+    # load tsv file as corpus
+    list_of_texts = []
+    with open(file) as csvfile:
+        reader = csv.reader(csvfile)
+        for row in reader:
+            row2string = ''.join(str(e) for e in row)
+            rowSplited = row2string.split('\t')
+            parapraph = rowSplited[1]
+            list_of_texts.append(parapraph)
+
+    list_of_texts = [text_preprocessing(text) for text in list_of_texts]
+    list_of_lemmatized_texts = spacy_lemmatizer_with_whitespace(list_of_texts, language)
+
+    list_of_df_keywords = []
+    for name, extractor in keyphrase_extractors.items():
+        if name in groups_of_algorithms["textacy"]:
+            for pos in include_pos:
+                print("Extracting keyphrases using " + name + " for " + pos)
+                list_of_lists_of_keywords = Parallel(n_jobs=1)(
+                    delayed(extractor)(text, language, pos) for text in tqdm(list_of_texts, position=1))
+                df_keywords = postprocessing(list_of_lists_of_keywords, name, pos)
+                list_of_df_keywords.append(df_keywords)
+        else:
+            list_of_lists_of_keywords = Parallel(n_jobs=1)(
+            delayed(extractor)(text, language) for text in tqdm(list_of_lemmatized_texts, position=1))
+            df_keywords = postprocessing(list_of_lists_of_keywords, name, None)
+            list_of_df_keywords.append(df_keywords)
+
+    df_keywords = pd.concat(list_of_df_keywords, axis=1)
+    filename = './output/'+str(file).split('/')[-1].split('.')[0]+'_single_keywords'+'.csv'
+    df_keywords.to_csv(filename, sep='\t', encoding='utf-8')
+
+
+file = "./input/contact_details.tsv"
+analyse(file)
+file = './input/user_rights_sentences.tsv'
+analyse(file)

--- a/event_extraction/output/contact_details_single_keywords.csv
+++ b/event_extraction/output/contact_details_single_keywords.csv
@@ -1,0 +1,1064 @@
+	KeyBert	KeyBert_Freq	TextRank_NOUN	TextRank_NOUN_Freq	TextRank_PROPN	TextRank_PROPN_Freq	TextRank_VERB	TextRank_VERB_Freq	SingleRank_NOUN	SingleRank_NOUN_Freq	SingleRank_PROPN	SingleRank_PROPN_Freq	SingleRank_VERB	SingleRank_VERB_Freq	PositionRank_NOUN	PositionRank_NOUN_Freq	PositionRank_PROPN	PositionRank_PROPN_Freq	PositionRank_VERB	PositionRank_VERB_Freq	MultipartiteRank	MultipartiteRank_Freq	Yake_NOUN	Yake_NOUN_Freq	Yake_PROPN	Yake_PROPN_Freq	Yake_VERB	Yake_VERB_Freq	sCAKE_NOUN	sCAKE_NOUN_Freq	sCAKE_PROPN	sCAKE_PROPN_Freq	sCAKE_VERB	sCAKE_VERB_Freq	SGRank_NOUN	SGRank_NOUN_Freq	SGRank_PROPN	SGRank_PROPN_Freq	SGRank_VERB	SGRank_VERB_Freq
+0	contact	513	question	252.0	privacy policy	118.0	contact	491.0	question	252.0	privacy policy	118.0	contact	491.0	question	252.0	privacy policy	118.0	contact	491.0	contact	460.0	question	287.0	privacy	154.0	contact	488.0	question	176.0	data protection officer	23.0	contact	175.0	question	250.0	privacy	146.0	contact	308.0
+1	email	427	information	140.0	data protection officer	23.0	send	56.0	information	140.0	data protection officer	23.0	send	56.0	information	140.0	data protection officer	23.0	send	56.0	question	216.0	information	167.0	policy	132.0	send	56.0	information	124.0	privacy policy	20.0	exercise	39.0	information	161.0	policy	127.0	exercise	53.0
+2	question	285	email	85.0	privacy	10.0	exercise	55.0	email	90.0	privacy	10.0	exercise	55.0	email	92.0	privacy	10.0	exercise	55.0	privacy policy	146.0	email	102.0	data	48.0	exercise	55.0	email	65.0	united kingdom	5.0	like	38.0	email	96.0	data	45.0	provide	46.0
+3	privacy	226	right	64.0	data protection	7.0	provide	46.0	right	64.0	data protection	7.0	provide	46.0	right	64.0	data protection	7.0	provide	46.0	email	129.0	privacy	93.0	protection	40.0	provide	46.0	concern	55.0	netherlands	4.0	wish	37.0	privacy	92.0	protection	40.0	send	44.0
+4	policy	204	-email-	61.0	california	6.0	email	44.0	concern	58.0	california	6.0	email	44.0	concern	58.0	california	6.0	email	44.0	information	122.0	datum	81.0	officer	31.0	email	44.0	datum	51.0	office	4.0	send	35.0	datum	78.0	officer	30.0	wish	40.0
+5	information	171	concern	58.0	policy	6.0	wish	40.0	request	58.0	policy	6.0	wish	40.0	request	58.0	policy	6.0	wish	40.0	use	81.0	policy	78.0	limited	13.0	wish	40.0	request	49.0	united states	4.0	provide	34.0	policy	78.0	limited	13.0	believe	40.0
+6	personal	119	request	58.0	data	5.0	believe	40.0	datum	57.0	data	5.0	believe	40.0	datum	57.0	data	5.0	believe	40.0	request	59.0	concern	70.0	street	13.0	believe	40.0	right	45.0	gdpr	4.0	believe	32.0	concern	70.0	support	12.0	like	39.0
+7	use	97	datum	57.0	united kingdom	5.0	like	39.0	-email-	51.0	united kingdom	5.0	like	39.0	-email-	51.0	united kingdom	5.0	like	39.0	datum	55.0	-email-	69.0	support	12.0	like	39.0	-email-	41.0	european economic area	3.0	want	24.0	request	64.0	street	12.0	email	39.0
+8	data	94	policy	44.0	eu	5.0	write	29.0	policy	44.0	eu	5.0	write	29.0	policy	44.0	eu	5.0	write	29.0	exercise	54.0	request	68.0	london	11.0	write	29.0	child	37.0	efta states	3.0	email	23.0	-email-	62.0	london	11.0	write	27.0
+9	request	82	child	43.0	european union	5.0	want	25.0	child	43.0	european union	5.0	want	25.0	child	43.0	european union	5.0	want	25.0	send	52.0	right	67.0	games	11.0	want	25.0	policy	31.0	barbara strozzilaan	3.0	delete	21.0	right	60.0	games	11.0	want	25.0
+10	concern	80	address	32.0	gdpr	5.0	use	23.0	address	32.0	gdpr	5.0	use	23.0	address	32.0	gdpr	5.0	use	23.0	concern	46.0	address	60.0	ltd	10.0	delete	24.0	privacy policy	30.0	san francisco	3.0	collect	20.0	address	55.0	ltd	10.0	delete	24.0
+11	datum	79	privacy policy	30.0	dpo	4.0	delete	22.0	privacy policy	30.0	dpo	4.0	delete	22.0	privacy policy	30.0	dpo	4.0	delete	22.0	data protection officer	44.0	data	52.0	california	9.0	use	22.0	age	29.0	zuuks games	3.0	use	19.0	data	52.0	united	9.0	use	22.0
+12	regard	79	service	29.0	netherlands	4.0	feel	20.0	mail	30.0	netherlands	4.0	feel	20.0	service	29.0	netherlands	4.0	feel	20.0	right	42.0	practice	46.0	united	9.0	collect	22.0	service	27.0	eu	3.0	write	19.0	practice	46.0	european	8.0	collect	22.0
+13	address	72	age	29.0	office	4.0	collect	20.0	service	29.0	office	4.0	collect	20.0	age	29.0	office	4.0	collect	20.0	child	42.0	child	44.0	information	9.0	feel	20.0	use	25.0	california	3.0	receive	17.0	child	44.0	information	8.0	feel	20.0
+14	protection	70	use	27.0	united states	4.0	reach	19.0	age	29.0	united states	4.0	reach	19.0	mail	28.0	united states	4.0	reach	19.0	believe	40.0	service	43.0	customer	8.0	reach	19.0	address	24.0	privacy statement	3.0	process	14.0	service	43.0	customer	7.0	receive	18.0
+15	right	66	mail	25.0	u.s.-based	3.0	request	18.0	use	27.0	u.s.-based	3.0	request	18.0	use	27.0	u.s.-based	3.0	request	18.0	policy	40.0	contact	42.0	european	8.0	receive	18.0	time	22.0	european union	3.0	know	13.0	contact	42.0	uk	7.0	request	18.0
+16	officer	61	time	24.0	european economic area	3.0	receive	17.0	time	24.0	european economic area	3.0	receive	17.0	time	24.0	european economic area	3.0	receive	17.0	wish	39.0	comment	42.0	services	8.0	request	18.0	complaint	22.0	platform	3.0	include	11.0	comment	41.0	services	7.0	process	18.0
+17	send	56	complaint	23.0	efta states	3.0	find	16.0	complaint	23.0	efta states	3.0	find	16.0	complaint	23.0	efta states	3.0	find	16.0	like	38.0	protection	33.0	eu	8.0	process	18.0	privacy	21.0	privacy center	3.0	hold	11.0	use	34.0	california	7.0	relate	14.0
+18	exercise	52	comment	21.0	barbara strozzilaan	3.0	process	16.0	comment	21.0	barbara strozzilaan	3.0	process	16.0	comment	21.0	barbara strozzilaan	3.0	process	16.0	address	38.0	officer	31.0	uk	7.0	find	16.0	mail	19.0	privacy	2.0	update	11.0	protection	33.0	states	6.0	follow	14.0
+19	provide	46	privacy	21.0	-emailor	3.0	relate	14.0	privacy	21.0	-emailor	3.0	relate	14.0	privacy	21.0	-emailor	3.0	relate	14.0	provide	31.0	mail	30.0	states	6.0	relate	14.0	data protection officer	18.0	paris france	2.0	request	11.0	age	30.0	inc.	6.0	know	14.0
+20	service	46	practice	19.0	san francisco	3.0	know	14.0	practice	19.0	san francisco	3.0	know	14.0	practice	19.0	san francisco	3.0	know	14.0	age	28.0	age	30.0	europe	6.0	follow	14.0	practice	18.0	hn amsterdam	2.0	share	11.0	complaint	27.0	llc	6.0	include	12.0
+21	practice	46	data protection officer	18.0	privacy notice	3.0	follow	12.0	data protection officer	18.0	privacy notice	3.0	follow	12.0	data protection officer	18.0	privacy notice	3.0	follow	12.0	write	26.0	detail	29.0	inc.	6.0	know	14.0	privacy practice	18.0	w 44th street new york ny	2.0	let	10.0	detail	26.0	eu	6.0	address	12.0
+22	mail	45	website	18.0	zuuks games	3.0	include	12.0	website	18.0	zuuks games	3.0	include	12.0	website	18.0	zuuks games	3.0	include	12.0	question regard	25.0	use	28.0	llc	6.0	include	13.0	section	17.0	interactive	2.0	remove	9.0	mail	26.0	center	6.0	hold	11.0
+23	child	44	contact detail	18.0	privacy statement	3.0	update	12.0	contact detail	18.0	privacy statement	3.0	update	12.0	contact detail	18.0	privacy statement	3.0	update	12.0	e-mail	24.0	complaint	27.0	center	6.0	update	12.0	question comment	17.0	usa	2.0	resolve	9.0	support	26.0	san	5.0	update	11.0
+24	comment	42	privacy practice	18.0	support center	3.0	address	12.0	privacy practice	18.0	support center	3.0	address	12.0	privacy practice	18.0	support center	3.0	address	12.0	want	24.0	support	26.0	dpo	5.0	address	12.0	comment	16.0	thomson reuters	2.0	learn	9.0	party	25.0	kingdom	5.0	learn	11.0
+25	wish	40	suggestion	17.0	ico	3.0	hold	11.0	suggestion	17.0	ico	3.0	hold	11.0	suggestion	17.0	ico	3.0	hold	11.0	service	23.0	party	25.0	san	5.0	hold	11.0	website	15.0	uk limited	2.0	relate	8.0	officer	25.0	francisco	5.0	share	11.0
+26	believe	40	section	17.0	headspace	3.0	resolve	11.0	section	17.0	headspace	3.0	resolve	11.0	section	17.0	headspace	3.0	resolve	11.0	time	22.0	time	25.0	kingdom	5.0	resolve	11.0	party	14.0	professional	2.0	follow	8.0	time	25.0	union	5.0	resolve	10.0
+27	like	36	question comment	17.0	platform	3.0	learn	11.0	question comment	17.0	platform	3.0	learn	11.0	question comment	17.0	platform	3.0	learn	11.0	privacy	20.0	website	21.0	francisco	5.0	learn	11.0	way	14.0	south colonnade	2.0	access	8.0	website	20.0	office	5.0	find	10.0
+28	support	35	party	15.0	privacy center	3.0	visit	11.0	party	15.0	privacy center	3.0	visit	11.0	party	15.0	privacy center	3.0	visit	11.0	practice	19.0	section	20.0	union	5.0	visit	11.0	application	14.0	-emailor	2.0	feel	8.0	section	20.0	inc	5.0	concern	10.0
+29	url	33	way	15.0	email	2.0	share	11.0	way	15.0	email	2.0	share	11.0	way	15.0	email	2.0	share	11.0	concern regard	19.0	e	19.0	office	5.0	share	11.0	contact detail	14.0	-urlor	2.0	submit	7.0	account	18.0	twitter	5.0	let	10.0
+30	age	30	query	14.0	paris france	2.0	concern	10.0	query	14.0	paris france	2.0	concern	10.0	query	14.0	paris france	2.0	concern	10.0	reach	18.0	account	19.0	gdpr	5.0	concern	10.0	account	13.0	privacy shield	2.0	set	7.0	suggestion	17.0	europe	5.0	describe	9.0
+31	complaint	27	parent	14.0	hn amsterdam	2.0	let	10.0	parent	14.0	hn amsterdam	2.0	let	10.0	parent	14.0	hn amsterdam	2.0	let	10.0	comment	18.0	suggestion	17.0	inc	5.0	let	10.0	-url-	12.0	dpo	2.0	require	7.0	processing	17.0	paris	4.0	remove	9.0
+32	write	25	email address	14.0	support service	2.0	submit	9.0	email address	14.0	support service	2.0	describe	9.0	email address	14.0	support service	2.0	describe	9.0	feel	17.0	processing	17.0	twitter	5.0	submit	9.0	parent	12.0	rooster teeth productions llc	2.0	review	6.0	way	15.0	netherlands	4.0	visit	9.0
+33	want	25	account	14.0	w 44th street new york ny	2.0	describe	9.0	account	14.0	w 44th street new york ny	2.0	submit	9.0	account	14.0	w 44th street new york ny	2.0	submit	9.0	website	17.0	query	16.0	paris	4.0	describe	9.0	email address	12.0	e 51st st austin tx	2.0	modify	6.0	user	15.0	ny	4.0	access	9.0
+34	delete	24	application	14.0	interactive	2.0	remove	9.0	application	14.0	interactive	2.0	remove	9.0	application	14.0	interactive	2.0	remove	9.0	question comment	17.0	controller	16.0	netherlands	4.0	remove	9.0	relation	11.0	legal department	2.0	find	6.0	form	15.0	administrator	4.0	opt	9.0
+35	free	22	-url-	12.0	usa	2.0	refer	9.0	-url-	12.0	usa	2.0	refer	9.0	-url-	12.0	usa	2.0	refer	9.0	delete	16.0	way	15.0	ny	4.0	refer	9.0	copy	11.0	belarus minsk	2.0	change	6.0	application	15.0	usa	4.0	submit	8.0
+36	emailor	22	resident	12.0	uk limited	2.0	opt	9.0	resident	12.0	uk limited	2.0	opt	9.0	resident	12.0	thomson reuters	2.0	opt	9.0	party	15.0	user	15.0	administrator	4.0	access	9.0	inquiry	10.0	ico	2.0	opt	6.0	controller	15.0	reuters	4.0	reach	8.0
+37	time	22	copy	12.0	thomson reuters	2.0	direct	8.0	copy	12.0	thomson reuters	2.0	direct	8.0	copy	12.0	uk limited	2.0	direct	8.0	receive	15.0	form	15.0	usa	4.0	opt	9.0	resident	10.0	twitter international company	2.0	refer	6.0	query	14.0	thomson	4.0	set	7.0
+38	collect	22	relation	11.0	professional	2.0	access	8.0	relation	11.0	professional	2.0	access	8.0	relation	11.0	professional	2.0	access	8.0	parent	14.0	application	15.0	reuters	4.0	direct	8.0	data controller	10.0	yumobi tekhnolodzhi ooo support	2.0	ask	6.0	parent	14.0	statement	4.0	review	7.0
+39	party	21	detail	11.0	south colonnade	2.0	set	7.0	detail	11.0	south colonnade	2.0	set	7.0	detail	11.0	south colonnade	2.0	set	7.0	account	14.0	parent	14.0	thomson	4.0	set	7.0	query	9.0	privacy policy administrator	2.0	post	6.0	marketing	14.0	notice	4.0	require	7.0
+40	website	21	contact information	11.0	information	2.0	require	7.0	contact information	11.0	information	2.0	require	7.0	contact information	11.0	information	2.0	require	7.0	application	14.0	marketing	14.0	statement	4.0	review	7.0	guardian	9.0	information commissioner	2.0	obtain	6.0	law	13.0	department	4.0	need	7.0
+41	13	20	data controller	11.0	llc	2.0	need	7.0	data controller	11.0	webmartgroup	2.0	need	7.0	data controller	11.0	llc	2.0	need	7.0	complaint	14.0	law	13.0	notice	4.0	require	7.0	suggestion	9.0	faubourg saint	2.0	address	6.0	page	13.0	legal	4.0	modify	6.0
+42	feel	19	law	10.0	webmartgroup	2.0	review	6.0	e	10.0	llc	2.0	modify	6.0	law	10.0	webmartgroup	2.0	modify	6.0	privacy practice	14.0	-url-	13.0	personal	4.0	need	7.0	message	9.0	homa	2.0	visit	6.0	-url-	13.0	gdpr	4.0	hesitate	6.0
+43	reach	19	user	10.0	alexadra games	2.0	modify	6.0	law	10.0	alexadra games	2.0	review	6.0	user	10.0	alexadra games	2.0	review	6.0	way	13.0	page	13.0	legal	4.0	modify	6.0	user	8.0	sega europe limited customer services	2.0	describe	5.0	security	13.0	platform	4.0	change	6.0
+44	account	19	inquiry	10.0	minimum	2.0	hesitate	6.0	user	10.0	minimum	2.0	hesitate	6.0	inquiry	10.0	minimum	2.0	hesitate	6.0	collect	13.0	security	13.0	department	4.0	hesitate	6.0	attn	8.0	great west road brentford middlesex tw8	2.0	unsubscribe	5.0	copy	12.0	tower	3.0	refer	6.0
+45	section	19	term	9.0	services	2.0	change	6.0	inquiry	10.0	services	2.0	change	6.0	term	9.0	services	2.0	change	6.0	find	13.0	resident	12.0	platform	4.0	change	6.0	consent	8.0	mortimer street london w1 t	2.0	try	5.0	inquiry	12.0	service	3.0	respond	6.0
+46	make	19	guardian	9.0	-emailand	2.0	respond	6.0	term	9.0	-emailand	2.0	respond	6.0	guardian	9.0	-emailand	2.0	respond	6.0	know	13.0	copy	12.0	tower	3.0	respond	6.0	security	8.0	data privacy management grci law limited	2.0	need	5.0	relation	11.0	france	3.0	ask	6.0
+47	receive	18	officer	9.0	trustarc	2.0	ask	6.0	guardian	9.0	trustarc	2.0	ask	6.0	officer	9.0	trustarc	2.0	ask	6.0	query	12.0	inquiry	12.0	u.s.-based	3.0	ask	6.0	term	7.0	boyne tower bull ring lagavooren drogheda co	2.0	concern	5.0	resident	11.0	amsterdam	3.0	post	6.0
+48	legal	17	floor	9.0	-urlor	2.0	post	6.0	officer	9.0	-urlor	2.0	post	6.0	floor	9.0	-urlor	2.0	post	6.0	copy	12.0	relation	11.0	service	3.0	post	6.0	detail	7.0	governance europe	2.0	give	4.0	number	11.0	strozzilaan	3.0	obtain	6.0
+49	suggestion	17	message	9.0	privacy shield	2.0	obtain	6.0	floor	9.0	privacy shield	2.0	obtain	6.0	message	9.0	privacy shield	2.0	obtain	6.0	access	12.0	number	11.0	france	3.0	obtain	6.0	contact information	7.0	head	2.0	note	4.0	term	10.0	barbara	3.0	appoint	5.0
+50	access	17	attn	8.0	tantan	2.0	appoint	5.0	message	9.0	tantan	2.0	appoint	5.0	e	8.0	tantan	2.0	appoint	5.0	suggestion	12.0	term	10.0	barbara	3.0	appoint	5.0	law	7.0	spotify usa inc	2.0	reach	4.0	notice	10.0	york	3.0	locate	5.0
+51	process	17	consent	8.0	e 51st st austin tx	2.0	locate	5.0	consent	8.0	rooster teeth productions llc	2.0	locate	5.0	attn	8.0	rooster teeth productions llc	2.0	locate	5.0	section	12.0	notice	10.0	strozzilaan	3.0	locate	5.0	access	7.0	privacy office	2.0	view	4.0	guardian	9.0	new	3.0	unsubscribe	5.0
+52	customer	16	security	8.0	rooster teeth productions llc	2.0	unsubscribe	5.0	security	8.0	e 51st st austin tx	2.0	unsubscribe	5.0	consent	8.0	e 51st st austin tx	2.0	unsubscribe	5.0	relation	11.0	guardian	9.0	amsterdam	3.0	unsubscribe	5.0	processing	7.0	suntec tower	1.0	mention	4.0	issue	9.0	w	3.0	report	5.0
+53	applicable	16	content	7.0	legal department	2.0	welcome	5.0	content	7.0	legal department	2.0	welcome	5.0	security	8.0	legal department	2.0	welcome	5.0	process	11.0	floor	9.0	interactive	3.0	welcome	5.0	mail address	7.0	temasek	1.0	display	4.0	message	9.0	interactive	3.0	view	5.0
+54	query	16	access	7.0	personal	2.0	report	5.0	access	7.0	personal	2.0	report	5.0	content	7.0	personal	2.0	report	5.0	data controller	11.0	issue	9.0	w	3.0	report	5.0	floor	7.0	singapore	1.0	respond	4.0	matter	9.0	suite	3.0	display	5.0
+55	processing	16	processing	7.0	saygames	2.0	view	5.0	processing	7.0	saygames	2.0	view	5.0	access	7.0	saygames	2.0	view	5.0	post	10.0	message	9.0	new	3.0	view	5.0	notice	7.0	lingodeer	1.0	state	3.0	communication	9.0	south	3.0	try	5.0
+56	controller	16	mail address	7.0	belarus minsk	2.0	display	5.0	mail address	7.0	belarus minsk	2.0	display	5.0	processing	7.0	belarus minsk	2.0	display	5.0	law	10.0	matter	9.0	york	3.0	display	5.0	data protection	6.0	designated countriemay	1.0	notify	3.0	customer	8.0	zuuks	3.0	state	4.0
+57	law	15	enquiry	7.0	topface	2.0	register	5.0	enquiry	7.0	topface	2.0	register	5.0	mail address	7.0	topface	2.0	register	5.0	learn	10.0	communication	9.0	suite	3.0	register	5.0	basis	6.0	general data protection regulation	1.0	work	3.0	access	8.0	cyprus	3.0	give	4.0
+58	user	15	matter	7.0	twitter international company	2.0	try	5.0	attn	7.0	twitter international company	2.0	try	5.0	enquiry	7.0	twitter international company	2.0	try	5.0	contact detail	10.0	customer	8.0	south	3.0	try	5.0	enquiry	6.0	freedom circle	1.0	handle	3.0	collection	8.0	personal	3.0	note	4.0
+59	form	15	notice	7.0	yumobi tekhnolodzhi ooo support	2.0	live	5.0	matter	7.0	yumobi tekhnolodzhi ooo support	2.0	live	5.0	matter	7.0	yumobi tekhnolodzhi ooo support	2.0	live	5.0	-emailor	10.0	content	8.0	-emailor	3.0	live	5.0	matter	6.0	santa clara	1.0	head	3.0	consent	8.0	commissioner	3.0	think	4.0
+60	application	15	data protection	6.0	privacy policy administrator	2.0	state	4.0	notice	7.0	privacy policy administrator	2.0	state	4.0	notice	7.0	privacy policy administrator	2.0	state	4.0	inquiry	10.0	access	8.0	zuuks	3.0	state	4.0	form	6.0	metro customer service	1.0	limit	3.0	e	7.0	dpo	3.0	mail	4.0
+61	additional	14	e	6.0	information commissioner	2.0	give	4.0	data protection	6.0	information commissioner	2.0	give	4.0	data protection	6.0	information commissioner	2.0	give	4.0	let	10.0	collection	8.0	cyprus	3.0	give	4.0	content	6.0	privacy officer	1.0	withdraw	3.0	preference	7.0	st	3.0	list	4.0
+62	parent	14	post	6.0	faubourg saint	2.0	note	4.0	post	6.0	faubourg saint	2.0	note	4.0	post	6.0	faubourg saint	2.0	note	4.0	mail	10.0	attn	8.0	commissioner	3.0	note	4.0	order	5.0	twitters data protection officer	1.0	disclose	3.0	floor	7.0	company	3.0	mention	4.0
+63	update	14	basis	6.0	homa	2.0	think	4.0	basis	6.0	homa	2.0	think	4.0	basis	6.0	homa	2.0	think	4.0	detail	10.0	consent	8.0	st	3.0	think	4.0	datum use concern	5.0	des petites ecuries c	1.0	contain	3.0	game	7.0	international	3.0	apply	4.0
+64	marketing	14	order	6.0	contact	2.0	mail	4.0	order	6.0	contact	2.0	mail	4.0	order	6.0	contact	2.0	mail	4.0	submit	9.0	preference	7.0	saygames	3.0	mail	4.0	issue	5.0	internet privacy policy	1.0	correct	3.0	attn	7.0	centre	3.0	register	4.0
+65	direct	14	issue	6.0	great west road brentford middlesex tw8	2.0	list	4.0	issue	6.0	great west road brentford middlesex tw8	2.0	list	4.0	issue	6.0	sega europe limited customer services	2.0	list	4.0	email address	9.0	game	7.0	company	3.0	list	4.0	game	5.0	internet privacy policy administrator	1.0	explain	3.0	app	7.0	lane	3.0	notify	3.0
+66	following	14	form	6.0	sega europe limited customer services	2.0	mention	4.0	form	6.0	sega europe limited customer services	2.0	mention	4.0	form	6.0	great west road brentford middlesex tw8	2.0	mention	4.0	refer	9.0	enquiry	7.0	ico	3.0	mention	4.0	writing	5.0	eprivacy gmbh	1.0	prevent	3.0	company	7.0	w1	3.0	work	3.0
+67	know	14	page	6.0	mcdonald	2.0	notify	3.0	page	6.0	mcdonald	2.0	notify	3.0	page	6.0	mcdonald	2.0	notify	3.0	visit	9.0	app	7.0	international	3.0	apply	4.0	link	5.0	prof	1.0	list	3.0	content	7.0	homa	3.0	handle	3.0
+68	notice	14	datum use concern	5.0	mortimer street london w1 t	2.0	work	3.0	datum use concern	5.0	mortimer street london w1 t	2.0	work	3.0	datum use concern	5.0	mortimer street london w1 t	2.0	work	3.0	message	9.0	company	7.0	centre	3.0	notify	3.0	year	5.0	tap4fun co. ltd	1.0	compromise	3.0	purpose	7.0	contact	3.0	encourage	3.0
+69	way	13	office	5.0	boyne tower bull ring lagavooren drogheda co	2.0	handle	3.0	office	5.0	data privacy management grci law limited	2.0	handle	3.0	office	5.0	data privacy management grci law limited	2.0	handle	3.0	share	9.0	cookie	7.0	headspace	3.0	work	3.0	case	5.0	privacy administrator	1.0	inform	3.0	basis	6.0	road	3.0	deal	3.0
+70	follow	13	game	5.0	data privacy management grci law limited	2.0	e	3.0	game	5.0	boyne tower bull ring lagavooren drogheda co	2.0	encourage	3.0	game	5.0	boyne tower bull ring lagavooren drogheda co	2.0	encourage	3.0	term	8.0	purpose	7.0	lane	3.0	handle	3.0	event	5.0	chengdu sichuan china	1.0	add	2.0	order	6.0	sega	3.0	head	3.0
+71	page	13	writing	5.0	governance europe	2.0	encourage	3.0	writing	5.0	governance europe	2.0	deal	3.0	writing	5.0	governance europe	2.0	deal	3.0	guardian	8.0	post	6.0	w1	3.0	e	3.0	violation	5.0	tianfu	1.0	infringe	2.0	link	6.0	spotify	3.0	remain	3.0
+72	security	13	link	5.0	head	2.0	deal	3.0	link	5.0	head	2.0	head	3.0	link	5.0	head	2.0	head	3.0	remove	8.0	basis	6.0	homa	3.0	encourage	3.0	site	5.0	tile inc.	1.0	violate	2.0	feedback	6.0	email	2.0	limit	3.0
+73	relate	12	year	5.0	spotify usa inc	2.0	head	3.0	year	5.0	spotify usa inc	2.0	remain	3.0	year	5.0	spotify usa inc	2.0	remain	3.0	resolve	8.0	order	6.0	contact	3.0	deal	3.0	claim	5.0	s el camino real suite	1.0	encourage	2.0	year	6.0	efta	2.0	stop	3.0
+74	include	12	case	5.0	privacy office	2.0	remain	3.0	case	5.0	privacy office	2.0	limit	3.0	case	5.0	privacy office	2.0	limit	3.0	user	8.0	link	6.0	sega	3.0	head	3.0	description	5.0	san mateo	1.0	investigate	2.0	enquiry	6.0	area	2.0	withdraw	3.0
+75	post	12	event	5.0	suntec tower	1.0	limit	3.0	event	5.0	suntec tower	1.0	withdraw	3.0	event	5.0	suntec tower	1.0	withdraw	3.0	california resident	8.0	feedback	6.0	road	3.0	remain	3.0	respect	5.0	privacy team thomson reuters	1.0	log	2.0	list	6.0	economic	2.0	cover	3.0
+76	resident	12	site	5.0	singapore	1.0	withdraw	3.0	violation	5.0	temasek	1.0	cover	3.0	violation	5.0	temasek	1.0	cover	3.0	include	8.0	year	6.0	spotify	3.0	stop	3.0	marketing communication	5.0	canary wharf london	1.0	erase	2.0	mailing	6.0	hn	2.0	disclose	3.0
+77	copy	12	violation	5.0	temasek	1.0	cover	3.0	site	5.0	singapore	1.0	disclose	3.0	site	5.0	singapore	1.0	disclose	3.0	consent	8.0	mailing	6.0	email	2.0	limit	3.0	cookie	5.0	statement	1.0	deal	2.0	violation	6.0	social	2.0	contain	3.0
+78	inquiry	12	claim	5.0	jagex limited	1.0	disclose	3.0	claim	5.0	jagex limited	1.0	contain	3.0	claim	5.0	jagex limited	1.0	contain	3.0	describe	8.0	list	6.0	economic	2.0	withdraw	3.0	page	5.0	data protection officer thomson reuters	1.0	permit	2.0	cookie	6.0	44th	2.0	correct	3.0
+79	immediately	11	description	5.0	lingodeer	1.0	contain	3.0	description	5.0	lingodeer	1.0	correct	3.0	description	5.0	lingodeer	1.0	correct	3.0	security	8.0	violation	6.0	area	2.0	cover	3.0	privacy question	4.0	canary wharf london e14	1.0	open	2.0	post	5.0	internet	2.0	explain	3.0
+80	resolve	11	respect	5.0	designated countriemay	1.0	correct	3.0	respect	5.0	designated countriemay	1.0	explain	3.0	respect	5.0	designated countriemay	1.0	explain	3.0	question concern	8.0	team	5.0	efta	2.0	disclose	3.0	regard	4.0	twitch services	1.0	seek	2.0	team	5.0	professional	2.0	prevent	3.0
+81	office	11	marketing communication	5.0	general data protection regulation	1.0	explain	3.0	marketing communication	5.0	general data protection regulation	1.0	prevent	3.0	marketing communication	5.0	general data protection regulation	1.0	prevent	3.0	contact information	7.0	dispute	5.0	hn	2.0	contain	3.0	post	4.0	twitch interactive inc.	1.0	arise	2.0	dispute	5.0	wharf	2.0	compromise	3.0
+82	number	11	cookie	5.0	freedom circle	1.0	prevent	3.0	cookie	5.0	santa clara	1.0	compromise	3.0	cookie	5.0	santa clara	1.0	compromise	3.0	follow	7.0	phone	5.0	social	2.0	correct	3.0	party dispute resolution provider	4.0	bush street	1.0	occur	2.0	phone	5.0	canary	2.0	inform	3.0
+83	street	11	privacy question	4.0	santa clara	1.0	compromise	3.0	privacy question	4.0	freedom circle	1.0	inform	3.0	privacy question	4.0	freedom circle	1.0	inform	3.0	complaint regard	7.0	office	5.0	internet	2.0	base	3.0	charge	4.0	vertigo games sepapaja	1.0	stop	2.0	office	5.0	team	2.0	disable	3.0
+84	emailand	11	dpo	4.0	customer	1.0	inform	3.0	dpo	4.0	customer	1.0	disable	3.0	dpo	4.0	customer	1.0	disable	3.0	hold	7.0	subject	5.0	44th	2.0	explain	3.0	office	4.0	tallinn	1.0	appoint	2.0	subject	5.0	colonnade	2.0	protect	3.0
+85	games	11	regard	4.0	metro customer service	1.0	disable	3.0	regard	4.0	metro customer service	1.0	protect	3.0	regard	4.0	metro customer service	1.0	protect	3.0	contact detail provide	7.0	writing	5.0	professional	2.0	prevent	3.0	abuse	4.0	estonia	1.0	allow	2.0	writing	5.0	-emailor	2.0	add	2.0
+86	share	11	party dispute resolution provider	4.0	privacy officer	1.0	protect	3.0	party dispute resolution provider	4.0	privacy officer	1.0	add	2.0	party dispute resolution provider	4.0	privacy officer	1.0	add	2.0	notice	7.0	case	5.0	team	2.0	act	3.0	file	4.0	information	1.0	publish	2.0	case	5.0	bush	2.0	violate	2.0
+87	hold	10	charge	4.0	twitters data protection officer	1.0	add	2.0	charge	4.0	twitters data protection officer	1.0	violate	2.0	charge	4.0	twitters data protection officer	1.0	violate	2.0	respect	7.0	event	5.0	colonnade	2.0	compromise	3.0	collection	4.0	zynga inc.	1.0	follow apply	2.0	event	5.0	webmartgroup	2.0	infringe	2.0
+88	ca	10	feedback	4.0	europe	1.0	violate	2.0	feedback	4.0	europe	1.0	infringe	2.0	feedback	4.0	europe	1.0	infringe	2.0	question relate	6.0	site	5.0	canary	2.0	inform	3.0	data processing	4.0	customer support page	1.0	understand	2.0	site	5.0	alexadra	2.0	e	2.0
+89	issue	10	abuse	4.0	des petites ecuries c	1.0	infringe	2.0	abuse	4.0	des petites ecuries c	1.0	e	2.0	abuse	4.0	des petites ecuries c	1.0	e	2.0	content	6.0	claim	5.0	wharf	2.0	disable	3.0	app	4.0	street san francisco	1.0	endeavour	2.0	claim	5.0	avenue	2.0	offer	2.0
+90	learn	10	file	4.0	rules	1.0	offer	2.0	file	4.0	rules	1.0	offer	2.0	file	4.0	rules	1.0	offer	2.0	basis	6.0	description	5.0	bush	2.0	protect	3.0	question concern	4.0	gdask poland	1.0	file	2.0	description	5.0	nicosia	2.0	investigate	2.0
+91	california	10	collection	4.0	relive	1.0	investigate	2.0	collection	4.0	relive	1.0	investigate	2.0	collection	4.0	relive	1.0	investigate	2.0	processing	6.0	respect	5.0	webmartgroup	2.0	add	2.0	marketing purpose	4.0	zacna	1.0	live	2.0	respect	5.0	microsoft	2.0	help	2.0
+92	visit	10	problem	4.0	skg	1.0	indicate	2.0	problem	4.0	skg	1.0	indicate	2.0	problem	4.0	skg	1.0	indicate	2.0	hesitate	6.0	telephone	5.0	alexadra	2.0	infringe	2.0	customer service	3.0	street	1.0	transfer	2.0	telephone	5.0	representative	2.0	log	2.0
+93	let	10	data processing	4.0	storytel	1.0	log	2.0	data processing	4.0	storytel	1.0	log	2.0	data processing	4.0	storytel	1.0	log	2.0	update	6.0	safeguard	5.0	minimum	2.0	violate	2.0	dpo	3.0	lockhart ro wan chai h.k	1.0	stay	2.0	registration	5.0	-urlor	2.0	erase	2.0
+94	list	10	removal	4.0	social club	1.0	erase	2.0	removal	4.0	social club	1.0	erase	2.0	removal	4.0	social club	1.0	erase	2.0	privacy officer	6.0	registration	5.0	nicosia	2.0	offer	2.0	accordance	3.0	rm	1.0	read	2.0	center	5.0	studios	2.0	store	2.0
+95	london	10	app	4.0	social point	1.0	store	2.0	app	4.0	social point	1.0	store	2.0	app	4.0	social point	1.0	store	2.0	unsubscribe	6.0	center	5.0	avenue	2.0	help	2.0	feedback	3.0	lockhart	1.0	invoke	2.0	authority	4.0	shield	2.0	seek	2.0
+96	center	10	question concern	4.0	internet privacy policy	1.0	permit	2.0	question concern	4.0	internet privacy policy	1.0	open	2.0	question concern	4.0	internet privacy policy	1.0	open	2.0	file	6.0	authority	4.0	-emailand	2.0	investigate	2.0	service support	3.0	dvapps ab	1.0	detail	2.0	owner	4.0	code	2.0	open	2.0
+97	submit	9	preference	4.0	internet privacy policy administrator	1.0	open	2.0	preference	4.0	internet privacy policy administrator	1.0	seek	2.0	preference	4.0	internet privacy policy administrator	1.0	permit	2.0	respond	6.0	owner	4.0	microsoft	2.0	log	2.0	e	3.0	dvloper	1.0	assist	2.0	regard	4.0	tx	2.0	permit	2.0
+98	dpo	9	marketing purpose	4.0	eprivacy gmbh	1.0	seek	2.0	marketing purpose	4.0	eprivacy gmbh	1.0	permit	2.0	marketing purpose	4.0	eprivacy gmbh	1.0	seek	2.0	need	6.0	dpo	4.0	trustarc	2.0	erase	2.0	instruction	3.0	easybrain ltd	1.0	respect	2.0	unsubscribe	4.0	austin	2.0	arise	2.0
+99	limited	9	safeguard	4.0	prof	1.0	arise	2.0	safeguard	4.0	prof	1.0	arise	2.0	safeguard	4.0	prof	1.0	arise	2.0	data protection	5.0	regard	4.0	representative	2.0	store	2.0	reason	3.0	krinou street	1.0	ensure	2.0	charge	4.0	51st	2.0	occur	2.0
+100	guardian	9	letter	4.0	tandem	1.0	occur	2.0	letter	4.0	tandem	1.0	occur	2.0	letter	4.0	tandem	1.0	occur	2.0	appoint	5.0	unsubscribe	4.0	-urlor	2.0	seek	2.0	mailing list	3.0	limassol cyprus	1.0	register	2.0	provider	4.0	e	2.0	allow	2.0
+101	remove	9	choice	4.0	chengdu sichuan china	1.0	stop	2.0	choice	4.0	tap4fun co. ltd	1.0	stop	2.0	choice	4.0	tap4fun co. ltd	1.0	stop	2.0	regard	5.0	resolution	4.0	studios	2.0	permit	2.0	phone	3.0	oval	1.0	disable	2.0	resolution	4.0	productions	2.0	publish	2.0
+102	16	9	customer service	3.0	tap4fun co. ltd	1.0	allow	2.0	customer service	3.0	privacy administrator	1.0	allow	2.0	customer service	3.0	privacy administrator	1.0	allow	2.0	modify	5.0	provider	4.0	shield	2.0	open	2.0	erasure	3.0	stakhanovskaya	1.0	agree	2.0	instruction	4.0	teeth	2.0	understand	2.0
+103	refer	9	version	3.0	privacy administrator	1.0	publish	2.0	version	3.0	chengdu sichuan china	1.0	publish	2.0	version	3.0	tianfu	1.0	publish	2.0	review	5.0	charge	4.0	tantan	2.0	arise	2.0	day	3.0	technopark perm	1.0	protect	2.0	help	4.0	rooster	2.0	base	2.0
+104	welcome	9	authority	3.0	tianfu	1.0	follow apply	2.0	authority	3.0	tianfu	1.0	follow apply	2.0	authority	3.0	chengdu sichuan china	1.0	follow apply	2.0	order	5.0	instruction	4.0	code	2.0	occur	2.0	removal	3.0	strovolos avenue petousis	1.0	enforce	2.0	abuse	4.0	minsk	2.0	endeavour	2.0
+105	message	9	support team	3.0	ted sites	1.0	understand	2.0	support team	3.0	ted sites	1.0	understand	2.0	support team	3.0	ted sites	1.0	understand	2.0	office	5.0	help	4.0	google	2.0	allow	2.0	officer	3.0	strovolos nicosia cyprus	1.0	age	1.0	file	4.0	belarus	2.0	file	2.0
+106	opt	9	accordance	3.0	s el camino real suite	1.0	base	2.0	accordance	3.0	s el camino real suite	1.0	base	2.0	accordance	3.0	s el camino real suite	1.0	base	2.0	require	5.0	abuse	4.0	rooster	2.0	publish	2.0	list	3.0	personal data protection	1.0	discontinue receive	1.0	feature	4.0	terms	2.0	live	2.0
+107	communication	9	marketing	3.0	tile inc.	1.0	endeavour	2.0	marketing	3.0	tile inc.	1.0	endeavour	2.0	marketing	3.0	tile inc.	1.0	endeavour	2.0	data	5.0	file	4.0	teeth	2.0	understand	2.0	mailing address	3.0	commissioner	1.0	adopt	1.0	letter	4.0	ico	2.0	transfer	2.0
+108	term	8	service support	3.0	san mateo	1.0	file	2.0	service support	3.0	san mateo	1.0	file	2.0	service support	3.0	san mateo	1.0	file	2.0	writing	5.0	assistance	4.0	productions	2.0	endeavour	2.0	data practice	3.0	genera games s.l cardenal bueno monreal	1.0	reply	1.0	choice	4.0	commissioners	2.0	stay	2.0
+109	directly	8	instruction	3.0	privacy team thomson reuters	1.0	transfer	2.0	instruction	3.0	privacy team thomson reuters	1.0	transfer	2.0	instruction	3.0	privacy team thomson reuters	1.0	transfer	2.0	year	5.0	problem	4.0	tx	2.0	file	2.0	contact	3.0	sevilla spain	1.0	help	1.0	business	4.0	rights	2.0	read	2.0
+110	unsubscribe	8	data	3.0	canary wharf london	1.0	stay	2.0	data	3.0	canary wharf london	1.0	stay	2.0	data	3.0	statement	1.0	stay	2.0	enquiry	5.0	feature	4.0	e	2.0	transfer	2.0	web form	3.0	planta	1.0	include delete	1.0	version	3.0	ooo	2.0	invoke	2.0
+111	floor	8	reason	3.0	statement	1.0	read	2.0	reason	3.0	statement	1.0	read	2.0	reason	3.0	canary wharf london	1.0	read	2.0	case	5.0	removal	4.0	austin	2.0	stay	2.0	individual	3.0	microsoft chief privacy officer	1.0	join	1.0	dpo	3.0	tekhnolodzhi	2.0	welcome	2.0
+112	subject	8	mailing list	3.0	data protection officer thomson reuters	1.0	invoke	2.0	mailing list	3.0	data protection officer thomson reuters	1.0	invoke	2.0	mailing list	3.0	data protection officer thomson reuters	1.0	invoke	2.0	change	5.0	letter	4.0	51st	2.0	read	2.0	preference	3.0	eu data protection officer	1.0	endeavor	1.0	accordance	3.0	yumobi	2.0	detail	2.0
+113	game	8	phone	3.0	canary wharf london e14	1.0	apply	2.0	phone	3.0	canary wharf london e14	1.0	apply	2.0	phone	3.0	canary wharf london e14	1.0	apply	2.0	attn	5.0	choice	4.0	belarus	2.0	invoke	2.0	registration number	3.0	eu local representative	1.0	collect process	1.0	member	3.0	market	2.0	assist	2.0
+114	collection	8	response	3.0	twitch interactive inc.	1.0	detail	2.0	response	3.0	twitch interactive inc.	1.0	detail	2.0	response	3.0	twitch interactive inc.	1.0	detail	2.0	request regard	5.0	business	4.0	minsk	2.0	detail	2.0	department	3.0	user information policy	1.0	store	1.0	statement	3.0	rue	2.0	respect	2.0
+115	consent	8	erasure	3.0	twitch services	1.0	assist	2.0	erasure	3.0	bush street	1.0	assist	2.0	erasure	3.0	twitch services	1.0	assist	2.0	privacy notice	5.0	version	3.0	terms	2.0	assist	2.0	support e	3.0	bank	1.0	restrict	1.0	line	3.0	sas	2.0	search	2.0
+116	services	8	day	3.0	bush street	1.0	respect	2.0	day	3.0	twitch services	1.0	respect	2.0	day	3.0	bush street	1.0	respect	2.0	head	5.0	accordance	3.0	topface	2.0	respect	2.0	letter	3.0	icbc	1.0	define	1.0	reason	3.0	itv	2.0	have	2.0
+117	detailed	8	assistance	3.0	vertigo games sepapaja	1.0	have	2.0	assistance	3.0	vertigo games sepapaja	1.0	have	2.0	assistance	3.0	vertigo games sepapaja	1.0	have	2.0	violation	5.0	member	3.0	commissioners	2.0	search	2.0	password	3.0	thinking ape entertainment ltd	1.0	possess	1.0	response	3.0	holborn	2.0	ensure	2.0
+118	eu	8	privacy officer	3.0	estonia	1.0	ensure	2.0	privacy officer	3.0	tallinn	1.0	ensure	2.0	privacy officer	3.0	tallinn	1.0	ensure	2.0	report	5.0	statement	3.0	rights	2.0	have	2.0	choice	3.0	ny ny	1.0	indicate	1.0	option	3.0	denis	2.0	act	2.0
+119	company	8	list	3.0	tallinn	1.0	act	2.0	list	3.0	estonia	1.0	act	2.0	list	3.0	estonia	1.0	act	2.0	site	5.0	reason	3.0	yumobi	2.0	ensure	2.0	help center	3.0	park avenue south	1.0	think	1.0	erasure	3.0	saint	2.0	agree	2.0
+120	urlor	8	mailing address	3.0	contextlogic b.v.s	1.0	agree	2.0	mailing address	3.0	contextlogic b.v.s	1.0	agree	2.0	mailing address	3.0	contextlogic b.v.s	1.0	agree	2.0	european union	5.0	line	3.0	tekhnolodzhi	2.0	agree	2.0	privacy notice	3.0	homer	1.0	abide	1.0	breach	3.0	faubourg	2.0	enforce	2.0
+121	responsible	7	company	3.0	street san francisco	1.0	enforce	2.0	company	3.0	customer support page	1.0	enforce	2.0	company	3.0	customer support page	1.0	enforce	2.0	description	5.0	building	3.0	ooo	2.0	enforce	2.0	business	3.0	support	1.0	redirect	1.0	day	3.0	tiktok	2.0	govern	1.0
+122	relation	7	data practice	3.0	customer support page	1.0	govern	1.0	data practice	3.0	zynga inc.	1.0	govern	1.0	data practice	3.0	zynga inc.	1.0	govern	1.0	ask	5.0	response	3.0	market	2.0	govern	1.0	drawer	3.0	amsterdam	1.0	accommodate	1.0	assistance	3.0	house	2.0	oversee	1.0
+123	set	7	contact	3.0	zynga inc.	1.0	oversee	1.0	contact	3.0	street san francisco	1.0	oversee	1.0	contact	3.0	street san francisco	1.0	oversee	1.0	-email-	5.0	agent	3.0	sas	2.0	oversee	1.0	keyword	2.0	letsvpn	1.0	alert	1.0	removal	3.0	floor	2.0	age	1.0
+124	content	7	web form	3.0	musixmatch	1.0	age	1.0	web form	3.0	musixmatch	1.0	age	1.0	web form	3.0	musixmatch	1.0	age	1.0	marketing communication	5.0	option	3.0	rue	2.0	age	1.0	contact datum	2.0	level	1.0	realise	1.0	activity	3.0	fireproof	2.0	consider	1.0
+125	review	7	individual	3.0	gdask poland	1.0	consider	1.0	individual	3.0	zacna	1.0	consider	1.0	individual	3.0	zacna	1.0	consider	1.0	list	5.0	erasure	3.0	cookie	2.0	consider	1.0	data protection law	2.0	lion??s data protection officer	1.0	issue	1.0	web	3.0	tw8	2.0	choose	1.0
+126	require	7	registration number	3.0	street	1.0	choose	1.0	registration number	3.0	street	1.0	choose	1.0	registration number	3.0	street	1.0	choose	1.0	app	5.0	breach	3.0	itv	2.0	choose	1.0	version	2.0	octaaf soudanstraat	1.0	base	1.0	individual	3.0	middlesex	2.0	discontinue	1.0
+127	european	7	department	3.0	zacna	1.0	discontinue receive	1.0	department	3.0	gdask poland	1.0	discontinue receive	1.0	department	3.0	gdask poland	1.0	discontinue receive	1.0	question regard privacy	5.0	day	3.0	holborn	2.0	discontinue	1.0	privacy email	2.0	sint	1.0	call	1.0	department	3.0	brentford	2.0	adopt	1.0
+128	statement	7	support e	3.0	camsurf	1.0	incur	1.0	support e	3.0	camsurf	1.0	incur	1.0	support e	3.0	camsurf	1.0	incur	1.0	try	5.0	activity	3.0	faubourg	2.0	incur	1.0	contact service page	2.0	denijs	1.0	come	1.0	-emailor	3.0	west	2.0	reply	1.0
+129	change	7	password	3.0	bluehole pnix	1.0	adopt	1.0	password	3.0	bluehole pnix	1.0	adopt	1.0	password	3.0	bluehole pnix	1.0	adopt	1.0	issue	5.0	web	3.0	saint	2.0	adopt	1.0	owner contact email	2.0	westrem	1.0	stop collect	1.0	password	3.0	great	2.0	join	1.0
+130	attn	7	help center	3.0	state	1.0	reply	1.0	help center	3.0	state	1.0	reply	1.0	help center	3.0	state	1.0	reply	1.0	form	5.0	individual	3.0	denis	2.0	reply	1.0	alternative	2.0	belgium	1.0	play	1.0	safeguard	3.0	t	2.0	represent	1.0
+131	soon	7	privacy notice	3.0	lockhart ro wan chai h.k	1.0	help	1.0	privacy notice	3.0	lockhart ro wan chai h.k	1.0	help	1.0	privacy notice	3.0	lockhart ro wan chai h.k	1.0	help	1.0	live	5.0	department	3.0	tiktok	2.0	join	1.0	nature	2.0	california civil code	1.0	forward	1.0	technology	3.0	mortimer	2.0	endeavor	1.0
+132	uk	7	business	3.0	rm	1.0	include delete	1.0	business	3.0	lockhart	1.0	include delete	1.0	business	3.0	lockhart	1.0	include delete	1.0	privacy question	4.0	-emailor	3.0	house	2.0	represent	1.0	account information	2.0	outfit7	1.0	prefer	1.0	drawer	3.0	b66	2.0	escalate	1.0
+133	minimum	7	drawer	3.0	lockhart	1.0	join	1.0	drawer	3.0	rm	1.0	join	1.0	drawer	3.0	rm	1.0	join	1.0	dpo	4.0	password	3.0	floor	2.0	endeavor	1.0	privacy right	2.0	privacy policy notice	1.0	specify	1.0	keyword	2.0	smethwick	2.0	restrict	1.0
+134	need	7	keyword	2.0	clicktouch games	1.0	represent	1.0	keyword	2.0	clicktouch games	1.0	represent	1.0	keyword	2.0	clicktouch games	1.0	represent	1.0	datum use concern	4.0	technology	3.0	england	2.0	escalate	1.0	scope	2.0	uber	1.0	act accord	1.0	nature	2.0	roebuck	2.0	aim	1.0
+135	respect	7	contact datum	2.0	dvapps ab	1.0	endeavor	1.0	contact datum	2.0	dvapps ab	1.0	endeavor	1.0	contact datum	2.0	dvapps ab	1.0	endeavor	1.0	charge	4.0	drawer	3.0	fireproof	2.0	restrict	1.0	visitor	2.0	rosh ha ayin industrial zone israel	1.0	mail	1.0	alternative	2.0	co	2.0	quote	1.0
+136	app	7	data protection law	2.0	dvloper	1.0	collect process	1.0	data protection law	2.0	dvloper	1.0	collect process	1.0	data protection law	2.0	dvloper	1.0	collect process	1.0	marketing	4.0	keyword	2.0	great	2.0	designate	1.0	support team	2.0	personal	1.0	adhere	1.0	regulation	2.0	drogheda	2.0	s	1.0
+137	purpose	7	privacy email	2.0	limassol cyprus	1.0	escalate	1.0	privacy email	2.0	krinou street	1.0	escalate	1.0	privacy email	2.0	krinou street	1.0	escalate	1.0	phone	4.0	entity	2.0	west	2.0	aim	1.0	datum privacy	2.0	microsoft	1.0	help solve	1.0	scope	2.0	lagavooren	2.0	define	1.0
+138	department	7	contact service page	2.0	easybrain ltd	1.0	restrict	1.0	contact service page	2.0	easybrain ltd	1.0	restrict	1.0	contact service page	2.0	easybrain ltd	1.0	restrict	1.0	game	4.0	nature	2.0	brentford	2.0	quote	1.0	privacy issue	2.0	limited liability company swag masha	1.0	track	1.0	visitor	2.0	ring	2.0	possess	1.0
+139	state	6	owner contact email	2.0	krinou street	1.0	designate	1.0	owner contact email	2.0	limassol cyprus	1.0	designate	1.0	owner contact email	2.0	limassol cyprus	1.0	designate	1.0	netherlands	4.0	alternative	2.0	middlesex	2.0	s	1.0	number	2.0	internatsionalnaya str	1.0	perform	1.0	testimonial	2.0	bull	2.0	indicate	1.0
+140	general	6	entity	2.0	oval	1.0	aim	1.0	entity	2.0	oval	1.0	aim	1.0	entity	2.0	oval	1.0	aim	1.0	e-mail address	4.0	regulation	2.0	tw8	2.0	define	1.0	data subject	2.0	republic	1.0	review delete	1.0	profile	2.0	boyne	2.0	abide	1.0
+141	team	6	alternative	2.0	technopark perm	1.0	quote	1.0	nature	2.0	technopark perm	1.0	quote	1.0	nature	2.0	technopark perm	1.0	quote	1.0	abuse	4.0	scope	2.0	mcdonald	2.0	possess	1.0	request form	2.0	terms	1.0	browse	1.0	mobile	2.0	governance	2.0	accommodate	1.0
+142	basis	6	nature	2.0	stakhanovskaya	1.0	s	1.0	alternative	2.0	stakhanovskaya	1.0	s	1.0	alternative	2.0	stakhanovskaya	1.0	s	1.0	update information	4.0	visitor	2.0	t	2.0	indicate	1.0	statement	2.0	support center	1.0	search	1.0	method	2.0	law	2.0	redirect	1.0
+143	emailwith	6	account information	2.0	strovolos nicosia cyprus	1.0	define	1.0	account information	2.0	strovolos avenue petousis	1.0	define	1.0	account information	2.0	strovolos avenue petousis	1.0	define	1.0	collection	4.0	testimonial	2.0	mortimer	2.0	abide	1.0	party information collection	2.0	personal information	1.0	tap	1.0	condition	2.0	grci	2.0	alert	1.0
+144	modify	6	privacy right	2.0	strovolos avenue petousis	1.0	possess	1.0	privacy right	2.0	strovolos nicosia cyprus	1.0	possess	1.0	privacy right	2.0	strovolos nicosia cyprus	1.0	possess	1.0	opt	4.0	profile	2.0	roebuck	2.0	redirect	1.0	method	2.0	doubleugames	1.0	scroll	1.0	administrator	2.0	management	2.0	realise	1.0
+145	emailif	6	scope	2.0	personal data protection	1.0	abide	1.0	scope	2.0	personal data protection	1.0	abide	1.0	scope	2.0	personal data protection	1.0	abide	1.0	matter	4.0	mobile	2.0	smethwick	2.0	accommodate	1.0	condition	2.0	aurora ave woodstock ga	1.0	report	1.0	building	2.0	head	2.0	issue	1.0
+146	hesitate	6	visitor	2.0	commissioner	1.0	redirect	1.0	visitor	2.0	commissioner	1.0	redirect	1.0	visitor	2.0	commissioner	1.0	redirect	1.0	problem	4.0	method	2.0	b66	2.0	alert	1.0	line	2.0	tastypill	1.0	express	1.0	instance	2.0	singapore	1.0	call	1.0
+147	preference	6	testimonial	2.0	genera games s.l cardenal bueno monreal	1.0	accommodate	1.0	testimonial	2.0	genera games s.l cardenal bueno monreal	1.0	accommodate	1.0	testimonial	2.0	genera games s.l cardenal bueno monreal	1.0	accommodate	1.0	email display	4.0	condition	2.0	apple	2.0	realise	1.0	administrator	2.0	testfoni	1.0	complain	1.0	device	2.0	suntec	1.0	come	1.0
+148	feedback	6	datum privacy	2.0	sevilla spain	1.0	alert	1.0	datum privacy	2.0	sevilla spain	1.0	alert	1.0	datum privacy	2.0	sevilla spain	1.0	alert	1.0	gdpr	4.0	administrator	2.0	co	2.0	issue	1.0	instance	2.0	topface	1.0	deactivate	1.0	representative	2.0	temasek	1.0	-emailuse	1.0
+149	online	6	privacy issue	2.0	planta	1.0	realise	1.0	privacy issue	2.0	planta	1.0	realise	1.0	privacy issue	2.0	planta	1.0	realise	1.0	cookie	4.0	instance	2.0	drogheda	2.0	call	1.0	device	2.0	nicosia cyprus	1.0	retain	1.0	rectification	2.0	jagex	1.0	play	1.0
+150	help	6	number	2.0	microsoft chief privacy officer	1.0	issue	1.0	number	2.0	eu data protection officer	1.0	issue	1.0	number	2.0	microsoft chief privacy officer	1.0	issue	1.0	opt-out	4.0	device	2.0	head	2.0	come	1.0	question comment complaint	2.0	boubolina	1.0	reflect	1.0	clarification	2.0	lingodeer	1.0	forward	1.0
+151	year	6	controller	2.0	eu data protection officer	1.0	call	1.0	controller	2.0	microsoft chief privacy officer	1.0	call	1.0	controller	2.0	eu data protection officer	1.0	call	1.0	marketing purpose	4.0	representative	2.0	management	2.0	-emailuse	1.0	clarification	2.0	information commissioners	1.0	locate	1.0	accident	2.0	countriemay	1.0	prefer	1.0
+152	enquiry	6	data subject	2.0	eu local representative	1.0	come	1.0	data subject	2.0	eu local representative	1.0	come	1.0	data subject	2.0	eu local representative	1.0	come	1.0	safeguard	4.0	rectification	2.0	grci	2.0	play	1.0	support service	2.0	sunnyvale	1.0	cancel	1.0	topic	2.0	designated	1.0	specify	1.0
+153	possible	6	request form	2.0	user information policy	1.0	-emailuse	1.0	request form	2.0	user information policy	1.0	-emailuse	1.0	request form	2.0	user information policy	1.0	-emailuse	1.0	united states	4.0	clarification	2.0	law	2.0	forward	1.0	datum breach	2.0	california privacy rights	1.0	select	1.0	identity	2.0	regulation	1.0	accord	1.0
+154	mailing	6	statement	2.0	icbc	1.0	stop collect	1.0	statement	2.0	bank	1.0	stop collect	1.0	statement	2.0	bank	1.0	stop collect	1.0	privacy statement	4.0	topic	2.0	governance	2.0	prefer	1.0	topic	2.0	privacy tubi inc	1.0	identify	1.0	addition	2.0	general	1.0	hear	1.0
+155	violation	6	party information collection	2.0	bank	1.0	play	1.0	party information collection	2.0	icbc	1.0	play	1.0	party information collection	2.0	icbc	1.0	play	1.0	support center	4.0	accident	2.0	boyne	2.0	specify	1.0	accident	2.0	montgomery street	1.0	welcome	1.0	body	2.0	clara	1.0	love	1.0
+156	site	6	method	2.0	thinking ape entertainment ltd	1.0	forward	1.0	method	2.0	thinking ape entertainment ltd	1.0	forward	1.0	method	2.0	thinking ape entertainment ltd	1.0	forward	1.0	letter	4.0	identity	2.0	bull	2.0	accord	1.0	support form	2.0	twitter inc	1.0	process base	1.0	explanation	2.0	santa	1.0	adhere	1.0
+157	file	6	condition	2.0	planb labs	1.0	prefer	1.0	condition	2.0	planb labs	1.0	prefer	1.0	condition	2.0	planb labs	1.0	prefer	1.0	-emailwe	4.0	addition	2.0	ring	2.0	love	1.0	assistance	2.0	twitter	1.0	involve	1.0	channel	2.0	circle	1.0	track	1.0
+158	llc	6	line	2.0	park avenue south	1.0	specify	1.0	line	2.0	park avenue south	1.0	specify	1.0	line	2.0	park avenue south	1.0	specify	1.0	platform	4.0	body	2.0	lagavooren	2.0	hear	1.0	identity	2.0	site applications	1.0	instal	1.0	client	2.0	freedom	1.0	solve	1.0
+159	respond	6	administrator	2.0	ny ny	1.0	act accord	1.0	administrator	2.0	ny ny	1.0	act accord	1.0	administrator	2.0	ny ny	1.0	act accord	1.0	privacy center	4.0	explanation	2.0	temasek	1.0	adhere	1.0	datum processing	2.0	services	1.0	conduct	1.0	telemarketing	2.0	metro	1.0	perform	1.0
+160	ask	6	building	2.0	homer	1.0	love hear	1.0	building	2.0	homer	1.0	love hear	1.0	building	2.0	homer	1.0	love hear	1.0	contact email	3.0	client	2.0	suntec	1.0	track	1.0	addition	2.0	google play /apple app store	1.0	-emailmake	1.0	satisfaction	2.0	twitters	1.0	browse	1.0
+161	obtain	6	instance	2.0	amsterdam	1.0	adhere	1.0	instance	2.0	support	1.0	adhere	1.0	instance	2.0	support	1.0	adhere	1.0	notify	3.0	channel	2.0	singapore	1.0	solve	1.0	body	2.0	ellation inc.	1.0	act	1.0	-urlfor	2.0	ecuries	1.0	tap	1.0
+162	cookie	6	device	2.0	support	1.0	help solve	1.0	device	2.0	amsterdam	1.0	track	1.0	device	2.0	amsterdam	1.0	track	1.0	customer service	3.0	telemarketing	2.0	jagex	1.0	fill	1.0	explanation	2.0	market st	1.0	search hit enter	1.0	acknowledgment	2.0	petites	1.0	scroll	1.0
+163	registered	6	question comment complaint	2.0	letsvpn	1.0	track	1.0	question comment complaint	2.0	letsvpn	1.0	help solve	1.0	question comment complaint	2.0	letsvpn	1.0	help solve	1.0	version	3.0	acknowledgment	2.0	lingodeer	1.0	perform	1.0	app support feature	2.0	rue pierre picard	1.0	esc	1.0	disclosure	2.0	des	1.0	discuss	1.0
+164	appoint	5	agent	2.0	game	1.0	fill	1.0	agent	2.0	game	1.0	fill	1.0	agent	2.0	game	1.0	fill	1.0	authority	3.0	satisfaction	2.0	designated	1.0	browse	1.0	company	2.0	dashlane sas	1.0	close	1.0	passport	2.0	club	1.0	express	1.0
+165	order	5	representative	2.0	level	1.0	perform	1.0	representative	2.0	level	1.0	perform	1.0	representative	2.0	level	1.0	perform	1.0	privacy policy include	3.0	-urlfor	2.0	countriemay	1.0	tap	1.0	processing activity	2.0	duolingo	1.0	entitle	1.0	misuse	2.0	point	1.0	complain	1.0
+166	link	5	clarification	2.0	lima sky	1.0	review delete	1.0	clarification	2.0	lima sky	1.0	review delete	1.0	clarification	2.0	lima sky	1.0	review delete	1.0	note	3.0	disclosure	2.0	general	1.0	scroll	1.0	privacy officer	2.0	data protection	1.0	recommend	1.0	measure	2.0	prof	1.0	retain	1.0
+167	dispute	5	support service	2.0	lion studios	1.0	browse	1.0	support service	2.0	lion studios	1.0	browse	1.0	support service	2.0	lion studios	1.0	browse	1.0	suggestion regard	3.0	passport	2.0	regulation	1.0	discuss	1.0	support page	2.0	stockholm sweden	1.0	have	1.0	problem	2.0	gmbh	1.0	deactivate	1.0
+168	phone	5	datum breach	2.0	lion??s data protection officer	1.0	scroll	1.0	datum breach	2.0	lion??s data protection officer	1.0	search	1.0	datum breach	2.0	lion??s data protection officer	1.0	search	1.0	account information	3.0	misuse	2.0	freedom	1.0	express	1.0	customer service channel	2.0	brunnsgatan	1.0	2019welcome	1.0	update	2.0	eprivacy	1.0	here	1.0
+169	mobile	5	accident	2.0	musescore	1.0	search	1.0	topic	2.0	musescore	1.0	scroll	1.0	topic	2.0	musescore	1.0	tap	1.0	think	3.0	system	2.0	circle	1.0	complain	1.0	client	2.0	gametion technologies pvt ltd	1.0	click	1.0	notification	2.0	china	1.0	reflect	1.0
+170	locate	5	topic	2.0	octaaf soudanstraat	1.0	tap	1.0	accident	2.0	octaaf soudanstraat	1.0	tap	1.0	accident	2.0	octaaf soudanstraat	1.0	scroll	1.0	work	3.0	measure	2.0	santa	1.0	deactivate	1.0	marketing	2.0	eea	1.0	create	1.0	agent	2.0	sichuan	1.0	select	1.0
+171	states	5	support form	2.0	sint	1.0	discuss	1.0	support form	2.0	sint	1.0	discuss	1.0	support form	2.0	sint	1.0	discuss	1.0	party dispute resolution provider	3.0	update	2.0	clara	1.0	retain	1.0	telemarketing	2.0	eu representative	1.0	upload	1.0	product	2.0	tianfu	1.0	cancel	1.0
+172	europe	5	identity	2.0	westrem	1.0	express	1.0	identity	2.0	denijs	1.0	express	1.0	identity	2.0	denijs	1.0	express	1.0	efta states	3.0	notification	2.0	metro	1.0	here	1.0	acknowledgment	2.0	liverpool street london ec2 m	1.0	sign	1.0	vat	2.0	chengdu	1.0	identify	1.0
+173	writing	5	datum processing	2.0	belgium	1.0	complain	1.0	datum processing	2.0	westrem	1.0	complain	1.0	datum processing	2.0	westrem	1.0	complain	1.0	european economic area	3.0	product	2.0	twitters	1.0	reflect	1.0	satisfaction	2.0	dpo centre	1.0	confirm	1.0	country	2.0	co.	1.0	instal	1.0
+174	administrator	5	addition	2.0	denijs	1.0	retain	1.0	addition	2.0	belgium	1.0	retain	1.0	addition	2.0	belgium	1.0	deactivate	1.0	encourage	3.0	vat	2.0	petites	1.0	select	1.0	-urlfor	2.0	gogogame	1.0	interact	1.0	safety	2.0	tap4fun	1.0	involve	1.0
+175	building	5	explanation	2.0	california civil code	1.0	deactivate	1.0	explanation	2.0	california civil code	1.0	deactivate	1.0	body	2.0	california civil code	1.0	retain	1.0	statement	3.0	country	2.0	ecuries	1.0	cancel	1.0	passport	2.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0	remain	1.0	delivery	2.0	ted	1.0	conduct	1.0
+176	san	5	body	2.0	outfit7	1.0	here	1.0	body	2.0	outfit7	1.0	here	1.0	explanation	2.0	outfit7	1.0	here	1.0	service support	3.0	safety	2.0	des	1.0	identify	1.0	misuse	2.0	beechavenue	1.0	elect	1.0	driver	2.0	sites	1.0	-emailmake	1.0
+177	united	5	app support feature	2.0	privacy policy notice	1.0	reflect	1.0	app support feature	2.0	privacy policy notice	1.0	reflect	1.0	app support feature	2.0	privacy policy notice	1.0	reflect	1.0	barbara strozzilaan	3.0	driver	2.0	rules	1.0	involve	1.0	purpose	2.0	schiphol	1.0	reset	1.0	boulevard	1.0	mateo	1.0	hit	1.0
+178	report	5	processing activity	2.0	kwalee	1.0	select	1.0	processing activity	2.0	kwalee	1.0	select	1.0	processing activity	2.0	kwalee	1.0	cancel	1.0	state	3.0	delivery	2.0	relive	1.0	instal	1.0	request question	2.0	rijk	1.0	misuse	1.0	state	1.0	real	1.0	enter	1.0
+179	matter	5	support page	2.0	uber	1.0	cancel	1.0	support page	2.0	uber	1.0	cancel	1.0	support page	2.0	uber	1.0	select	1.0	query regard	3.0	boulevard	1.0	skg	1.0	conduct	1.0	feedback page	2.0	data privacy officer	1.0	advise	1.0	portal	1.0	tile	1.0	close	1.0
+180	claim	5	customer service channel	2.0	rosh ha ayin industrial zone israel	1.0	identify	1.0	customer service channel	2.0	rosh ha ayin industrial zone israel	1.0	identify	1.0	customer service channel	2.0	rosh ha ayin industrial zone israel	1.0	identify	1.0	contact support service	3.0	exit	1.0	storytel	1.0	-emailmake	1.0	problem	2.0	twitter inc.	1.0	acquire	1.0	objection	1.0	camino	1.0	esc	1.0
+181	description	5	client	2.0	google	1.0	process base	1.0	client	2.0	google	1.0	involve	1.0	client	2.0	google	1.0	process base	1.0	reason	3.0	portal	1.0	club	1.0	hit	1.0	support	2.0	data protection officerone cumberland place fenian streetdublin	1.0	sell	1.0	widget	1.0	el	1.0	entitle	1.0
+182	display	5	telemarketing	2.0	diandian	1.0	involve	1.0	telemarketing	2.0	diandian	1.0	instal	1.0	telemarketing	2.0	diandian	1.0	involve	1.0	line	3.0	state	1.0	point	1.0	esc	1.0	safeguard	2.0	market street suite 900san francisco	1.0	buy	1.0	entity	1.0	e14	1.0	recommend	1.0
+183	register	5	acknowledgment	2.0	microsoft	1.0	instal	1.0	satisfaction	2.0	microsoft	1.0	process base	1.0	acknowledgment	2.0	microsoft	1.0	instal	1.0	privacy policy administrator	3.0	objection	1.0	prof	1.0	close	1.0	data	2.0	ireland	1.0	comply	1.0	cost	1.0	twitch	1.0	2019welcome	1.0
+184	try	5	-urlfor	2.0	limited liability company swag masha	1.0	conduct	1.0	-urlfor	2.0	limited liability company swag masha	1.0	conduct	1.0	satisfaction	2.0	limited liability company swag masha	1.0	conduct	1.0	deal	3.0	widget	1.0	eprivacy	1.0	enter	1.0	technology	2.0	tricor	1.0	apply	1.0	call	1.0	estonia	1.0	upload	1.0
+185	generally	5	satisfaction	2.0	internatsionalnaya str	1.0	-emailmake	1.0	acknowledgment	2.0	republic	1.0	-emailmake	1.0	-urlfor	2.0	republic	1.0	-emailmake	1.0	event	3.0	cost	1.0	gmbh	1.0	entitle	1.0	product	2.0	mark lane london	1.0	deliver	1.0	pay	1.0	tallinn	1.0	create	1.0
+186	gdpr	5	passport	2.0	republic	1.0	search hit enter	1.0	passport	2.0	internatsionalnaya str	1.0	search hit enter	1.0	passport	2.0	internatsionalnaya str	1.0	search hit enter	1.0	usa	3.0	pay	1.0	tandem	1.0	recommend	1.0	vat registration number	2.0	saygames llc	1.0	return	1.0	principle	1.0	sepapaja	1.0	click	1.0
+187	telephone	5	misuse	2.0	terms	1.0	close	1.0	misuse	2.0	terms	1.0	close	1.0	misuse	2.0	terms	1.0	esc	1.0	response	3.0	principle	1.0	china	1.0	2019welcome	1.0	team	2.0	addressable platform limited	1.0	attempt	1.0	com	1.0	vertigo	1.0	confirm	1.0
+188	safeguard	5	purpose	2.0	personal information	1.0	esc	1.0	purpose	2.0	personal information	1.0	esc	1.0	purpose	2.0	personal information	1.0	close	1.0	view	3.0	com	1.0	sichuan	1.0	click	1.0	telephone	2.0	itv	1.0	communicate	1.0	dot	1.0	b.v.s	1.0	sign	1.0
+189	registration	5	system	2.0	doubleugames	1.0	entitle	1.0	system	2.0	doubleugames	1.0	entitle	1.0	system	2.0	doubleugames	1.0	entitle	1.0	privacy practice relate	3.0	mondly	1.0	tap4fun	1.0	create	1.0	response	2.0	britbox	1.0	triage	1.0	mondly	1.0	contextlogic	1.0	interact	1.0
+190	emailwe	5	request question	2.0	aurora ave woodstock ga	1.0	recommend	1.0	request question	2.0	aurora ave woodstock ga	1.0	recommend	1.0	request question	2.0	aurora ave woodstock ga	1.0	recommend	1.0	limit	3.0	dot	1.0	co.	1.0	upload	1.0	country	2.0	itv rights limited	1.0	access rectify	1.0	manager	1.0	zynga	1.0	elect	1.0
+191	platform	5	feedback page	2.0	tastypill	1.0	2019welcome	1.0	feedback page	2.0	tastypill	1.0	2019welcome	1.0	feedback page	2.0	tastypill	1.0	2019welcome	1.0	information delete	3.0	manager	1.0	tianfu	1.0	talk	1.0	address telephone number	2.0	itv consumer limited	1.0	object	1.0	conduct	1.0	page	1.0	reset	1.0
+192	authority	4	support	2.0	testfoni	1.0	click	1.0	support	2.0	testfoni	1.0	click	1.0	support	2.0	testfoni	1.0	click	1.0	data processing	3.0	conduct	1.0	chengdu	1.0	sign	1.0	safety	2.0	holborn london ec1n	1.0	authenticate	1.0	merchandise	1.0	poland	1.0	advise	1.0
+193	think	4	datum controller	2.0	information commissioners	1.0	upload	1.0	datum controller	2.0	information commissioners	1.0	create	1.0	datum controller	2.0	nicosia cyprus	1.0	create	1.0	matter cover	3.0	example	1.0	ted	1.0	confirm	1.0	privacy matter	2.0	fremantle media limited	1.0	fulfil	1.0	example	1.0	gdask	1.0	misuse	1.0
+194	alternatively	4	communication	2.0	nicosia cyprus	1.0	create	1.0	communication	2.0	nicosia cyprus	1.0	upload	1.0	communication	2.0	information commissioners	1.0	upload	1.0	floor	3.0	merchandise	1.0	sites	1.0	interact	1.0	boulevard	1.0	stephen street london w1 t	1.0			k	1.0	zacna	1.0	buy	1.0
+195	provider	4	technology	2.0	boubolina	1.0	talk	1.0	technology	2.0	boubolina	1.0	talk	1.0	technology	2.0	boubolina	1.0	talk	1.0	obtain	3.0	k	1.0	tile	1.0	elect	1.0	datum protection officer	1.0	waterhouse square	1.0			-emailfrom	1.0	pnix	1.0	sell	1.0
+196	unresolved	4	product	2.0	sunnyvale	1.0	sign	1.0	product	2.0	sunnyvale	1.0	confirm	1.0	product	2.0	sunnyvale	1.0	confirm	1.0	company	3.0	-emailfrom	1.0	el	1.0	reset	1.0	datum protection law	1.0	got talent	1.0			nickname	1.0	bluehole	1.0	acquire	1.0
+197	satisfactorily	4	vat registration number	2.0	california privacy rights	1.0	confirm	1.0	vat registration number	2.0	california privacy rights	1.0	sign	1.0	vat registration number	2.0	california privacy rights	1.0	sign	1.0	correct	3.0	field	1.0	camino	1.0	misuse	1.0	datum protection regulation	1.0	x factor	1.0			field	1.0	state	1.0	comply	1.0
+198	charge	4	company number	2.0	privacy tubi inc	1.0	interact	1.0	company number	2.0	privacy tubi inc	1.0	interact	1.0	company number	2.0	privacy tubi inc	1.0	interact	1.0	data practice	3.0	nickname	1.0	real	1.0	advise	1.0	member state	1.0	britain	1.0			zone	1.0	h.k	1.0	deliver	1.0
+199	44	4	team	2.0	montgomery street	1.0	elect	1.0	team	2.0	montgomery street	1.0	elect	1.0	team	2.0	montgomery street	1.0	elect	1.0	web form	3.0	park	1.0	mateo	1.0	sell	1.0	portal	1.0	gb	1.0			tech	1.0	chai	1.0	attempt	1.0
+200	netherlands	4	telephone	2.0	twitter inc	1.0	reset	1.0	telephone	2.0	twitter inc	1.0	reset	1.0	telephone	2.0	twitter inc	1.0	reset	1.0	comment regard	3.0	tech	1.0	e14	1.0	buy	1.0	email address -email-	1.0	hydrane sas	1.0			park	1.0	wan	1.0	return	1.0
+201	instruction	4	country	2.0	twitter	1.0	advise	1.0	country	2.0	twitter	1.0	advise	1.0	country	2.0	twitter	1.0	misuse	1.0	individual	3.0	zone	1.0	twitch	1.0	acquire	1.0	objection	1.0	denis	1.0			software	1.0	ro	1.0	affect	1.0
+202	case	4	address telephone number	2.0	-emailwith	1.0	misuse	1.0	address telephone number	2.0	-emailwith	1.0	misuse	1.0	address telephone number	2.0	-emailwith	1.0	advise	1.0	preference	3.0	software	1.0	vertigo	1.0	comply	1.0	email preference	1.0	paris	1.0			code	1.0	lockhart	1.0	familiarize	1.0
+203	appropriate	4	safety	2.0	adobe	1.0	comply	1.0	safety	2.0	adobe	1.0	comply	1.0	safety	2.0	adobe	1.0	sell	1.0	explain	3.0	registry	1.0	sepapaja	1.0	deliver	1.0	unsubscribe link	1.0	denis paris france	1.0			registry	1.0	rm	1.0	communicate	1.0
+204	ny	4	privacy matter	2.0	site applications	1.0	acquire	1.0	privacy matter	2.0	site applications	1.0	sell	1.0	privacy matter	2.0	site applications	1.0	buy	1.0	page	3.0	code	1.0	tallinn	1.0	return	1.0	member profile	1.0	rue	1.0			offer	1.0	clicktouch	1.0	triage	1.0
+205	specific	4	boulevard	1.0	camel games	1.0	buy	1.0	boulevard	1.0	camel games	1.0	buy	1.0	boulevard	1.0	camel games	1.0	acquire	1.0	registration number	3.0	promotion	1.0	estonia	1.0	attempt	1.0	support widget	1.0	companyabout games blog jobs	1.0			promotion	1.0	ab	1.0	object	1.0
+206	reuters	4	datum protection officer	1.0	google play /apple app store	1.0	sell	1.0	datum protection officer	1.0	google play /apple app store	1.0	acquire	1.0	datum protection officer	1.0	google play /apple app store	1.0	comply	1.0	support e-mail	3.0	offer	1.0	contextlogic	1.0	affect	1.0	pay phone	1.0	games articles	1.0			newsletter	1.0	dvapps	1.0	rectify	1.0
+207	thomson	4	exit	1.0	ellation inc.	1.0	deliver	1.0	exit	1.0	ellation inc.	1.0	deliver	1.0	exit	1.0	ellation inc.	1.0	deliver	1.0	ico	3.0	newsletter	1.0	b.v.s	1.0	familiarize	1.0	call	1.0	twitter facebook linkedin	1.0			contextlogic	1.0	dvloper	1.0	enjoy	1.0
+208	kingdom	4	datum protection regulation	1.0	market st	1.0	return	1.0	datum protection law	1.0	market st	1.0	return	1.0	datum protection law	1.0	market st	1.0	return	1.0	support	3.0	contextlogic	1.0	zynga	1.0	communicate	1.0	cost	1.0	events careers	1.0			ticket	1.0	limassol	1.0	hope	1.0
+209	francisco	4	datum protection law	1.0	cube software	1.0	attempt	1.0	datum protection regulation	1.0	cube software	1.0	attempt	1.0	datum protection regulation	1.0	cube software	1.0	attempt	1.0	password	3.0	port	1.0	page	1.0	triage	1.0	mobile	1.0	tiktok inc	1.0			jurisdiction	1.0	oval	1.0	fulfil	1.0
+210	correct	4	member state	1.0	rue pierre picard	1.0	affect	1.0	member state	1.0	dashlane sas	1.0	affect	1.0	member state	1.0	dashlane sas	1.0	affect	1.0	inform	3.0	ticket	1.0	musixmatch	1.0	rectify	1.0	principle	1.0	tiktok legal department	1.0			receipt	1.0	krinou	1.0	authenticate	1.0
+211	abuse	4	portal	1.0	dashlane sas	1.0	familiarize	1.0	portal	1.0	rue pierre picard	1.0	familiarize	1.0	portal	1.0	rue pierre picard	1.0	familiarize	1.0	help center	3.0	jurisdiction	1.0	poland	1.0	object	1.0	mondly	1.0	venice blvd suite	1.0			juvenile	1.0	easybrain	1.0		
+212	view	4	email address -email-	1.0	dingtone	1.0	communicate	1.0	email address -email-	1.0	dingtone	1.0	communicate	1.0	email address -email-	1.0	dingtone	1.0	communicate	1.0	choice	3.0	receipt	1.0	gdask	1.0	enjoy	1.0	dot	1.0	culver city	1.0			forum	1.0	perm	1.0		
+213	representative	4	objection	1.0	duolingo	1.0	triage	1.0	objection	1.0	duolingo	1.0	triage	1.0	objection	1.0	duolingo	1.0	triage	1.0	disable	3.0	juvenile	1.0	zacna	1.0	hope	1.0	com	1.0	usaemail	1.0			blog	1.0	technopark	1.0		
+214	certain	4	email preference	1.0	stockholm sweden	1.0	access rectify	1.0	email preference	1.0	brunnsgatan	1.0	access rectify	1.0	email preference	1.0	brunnsgatan	1.0	access rectify	1.0	drawer	3.0	blog	1.0	camsurf	1.0	authenticate	1.0	manager contact information section	1.0	policy	1.0			decision	1.0	stakhanovskaya	1.0		
+215	union	4	unsubscribe link	1.0	brunnsgatan	1.0	object	1.0	member profile	1.0	stockholm sweden	1.0	object	1.0	unsubscribe link	1.0	stockholm sweden	1.0	object	1.0	address state	2.0	forum	1.0	pnix	1.0	fulfil	1.0	datum protection	1.0	october	1.0			word	1.0	strovolos	1.0		
+216	mention	4	member profile	1.0	gamegos	1.0	hope	1.0	unsubscribe link	1.0	gamegos	1.0	hope	1.0	member profile	1.0	gamegos	1.0	hope	1.0	add	2.0	decision	1.0	bluehole	1.0			data protection authority	1.0	bytedance uk limited aviation house	1.0			ctr	1.0	petousis	1.0		
+217	assistance	4	support widget	1.0	gametion technologies pvt ltd	1.0	enjoy	1.0	support widget	1.0	gametion technologies pvt ltd	1.0	enjoy	1.0	support widget	1.0	gametion technologies pvt ltd	1.0	enjoy	1.0	keyword data protection	2.0	word	1.0	state	1.0			conduct	1.0	kingsway holborn london wc2b	1.0			document	1.0	sevilla	1.0		
+218	problem	4	pay phone	1.0	eu representative	1.0	fulfil	1.0	pay phone	1.0	eu representative	1.0	authenticate	1.0	call	1.0	eu representative	1.0	authenticate	1.0	contact provide	2.0	ctr	1.0	h.k	1.0			website application	1.0	summarywhat	1.0			advertising	1.0	planta	1.0		
+219	limit	4	call	1.0	eea	1.0	authenticate	1.0	call	1.0	eea	1.0	fulfil	1.0	pay phone	1.0	eea	1.0	fulfil	1.0	data protection law	2.0	document	1.0	chai	1.0			help page	1.0	hays house north wing	1.0			tracking	1.0	spain	1.0		
+220	feature	4	mobile	1.0	liverpool street london ec2 m	1.0			mobile	1.0	liverpool street london ec2 m	1.0			cost	1.0	liverpool street london ec2 m	1.0			question contact	2.0	tracking	1.0	rm	1.0			example	1.0	floor millmead guildford surrey england gu2 4hj	1.0			meaning	1.0	monreal	1.0		
+221	removal	4	cost	1.0	dpo centre	1.0			cost	1.0	dpo centre	1.0			mobile	1.0	dpo centre	1.0			follow way	2.0	advertising	1.0	lockhart	1.0			merchandise	1.0	contact information	1.0			paragraph	1.0	bueno	1.0		
+222	apply	4	principle	1.0	gogogame	1.0			principle	1.0	gogogame	1.0			principle	1.0	gogogame	1.0			privacy email	2.0	meaning	1.0	ro	1.0			marketing preference	1.0	support centre	1.0			connection	1.0	cardenal	1.0		
+223	emailfor	4	mondly	1.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0			mondly	1.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0			mondly	1.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0			contact service page	2.0	paragraph	1.0	wan	1.0			k account information	1.0	data protection team	1.0			tool	1.0	s.l	1.0		
+224	forth	4	dot	1.0	rijk	1.0			dot	1.0	schiphol	1.0			dot	1.0	beechavenue	1.0			owner contact email	2.0	connection	1.0	clicktouch	1.0			email account	1.0	fireproof studios ltd	1.0			transfer	1.0	genera	1.0		
+225	aware	4	com	1.0	schiphol	1.0			com	1.0	rijk	1.0			com	1.0	schiphol	1.0			nature	2.0	handling	1.0	ab	1.0			-emailfrom	1.0	pepper deals ltd	1.0			handling	1.0	chief	1.0		
+226	live	4	manager contact information section	1.0	beechavenue	1.0			manager contact information section	1.0	beechavenue	1.0			manager contact information section	1.0	rijk	1.0			alternative	2.0	transfer	1.0	dvapps	1.0			subject field	1.0	batemans row london ec2a	1.0			mean	1.0	local	1.0		
+227	letter	4	datum protection	1.0	data privacy officer	1.0			datum protection	1.0	data privacy officer	1.0			datum protection	1.0	data privacy officer	1.0			support team	2.0	tool	1.0	dvloper	1.0			nickname	1.0	lindgreens	1.0			institution	1.0	icbc	1.0		
+228	ico	4	data protection authority	1.0	data protection officerone cumberland place fenian streetdublin	1.0			data protection authority	1.0	data protection officerone cumberland place fenian streetdublin	1.0			data protection authority	1.0	data protection officerone cumberland place fenian streetdublin	1.0			accordance	2.0	mean	1.0	limassol	1.0			subject line	1.0	k?benhavn sor	1.0			function	1.0	bank	1.0		
+229	twitter	4	conduct	1.0	market street suite 900san francisco	1.0			conduct	1.0	market street suite 900san francisco	1.0			conduct	1.0	market street suite 900san francisco	1.0			resident	2.0	function	1.0	easybrain	1.0			software park	1.0	restaurants limited customer services	1.0			database	1.0	user	1.0		
+230	business	4	website application	1.0	twitter inc.	1.0			website application	1.0	twitter inc.	1.0			website application	1.0	twitter inc.	1.0			-emailwith	2.0	institution	1.0	krinou	1.0			tech zone	1.0	high road east finchley london	1.0			hn	1.0	entertainment	1.0		
+231	entitled	3	help page	1.0	ireland	1.0			help page	1.0	ireland	1.0			help page	1.0	ireland	1.0			violate	2.0	database	1.0	oval	1.0			building	1.0	mcdonald	1.0			end	1.0	ape	1.0		
+232	notify	3	example	1.0	mark lane london	1.0			merchandise	1.0	tricor	1.0			merchandise	1.0	tricor	1.0			infringe	2.0	hn	1.0	technopark	1.0			owner	1.0	uk information commissioners office	1.0			opinion	1.0	thinking	1.0		
+233	tower	3	merchandise	1.0	tricor	1.0			example	1.0	mark lane london	1.0			example	1.0	mark lane london	1.0			scope	2.0	end	1.0	perm	1.0			registry code	1.0	legal department freeview	1.0			left	1.0	labs	1.0		
+234	version	3	marketing preference	1.0	saygames llc	1.0			marketing preference	1.0	saygames llc	1.0			marketing preference	1.0	saygames llc	1.0			visitor	2.0	opinion	1.0	stakhanovskaya	1.0			unsubscribe option	1.0	floor	1.0			setting	1.0	planb	1.0		
+235	urlfor	3	k account information	1.0	cookie	1.0			k account information	1.0	cookie	1.0			k account information	1.0	cookie	1.0			email use	2.0	setting	1.0	strovolos	1.0			promotion	1.0	dtv services ltd	1.0			advertiser	1.0	park	1.0		
+236	previous	3	email account	1.0	cookie policy	1.0			email account	1.0	cookie policy	1.0			email account	1.0	cookie policy	1.0			testimonial	2.0	left	1.0	petousis	1.0			offer	1.0	digital uk limited	1.0			partner	1.0	homer	1.0		
+237	current	3	subject field	1.0	direct	1.0			nickname	1.0	direct	1.0			-emailfrom	1.0	direct	1.0			datum privacy	2.0	personal	1.0	sevilla	1.0			newsletter	1.0	picsart inc.	1.0			personal	1.0	letsvpn	1.0		
+238	owner	3	-emailfrom	1.0	addressable platform limited	1.0			-emailfrom	1.0	addressable platform limited	1.0			nickname	1.0	addressable platform limited	1.0			privacy issue	2.0	advertiser	1.0	spain	1.0			datum use practice	1.0	california business	1.0			mind	1.0	game	1.0		
+239	note	3	nickname	1.0	britbox	1.0			subject field	1.0	itv	1.0			subject field	1.0	itv	1.0			handle	2.0	mind	1.0	genera	1.0			contextlogic use	1.0	sutter st.	1.0			sharing	1.0	level	1.0		
+240	accordance	3	subject line	1.0	itv	1.0			subject line	1.0	britbox	1.0			subject line	1.0	britbox	1.0			controller	2.0	partner	1.0	s.l	1.0			support ticket	1.0	professions code section	1.0			system	1.0	sky	1.0		
+241	lawful	3	tech zone	1.0	stephen street london w1 t	1.0			software park	1.0	stephen street london w1 t	1.0			software park	1.0	got talent	1.0			resolve issue	2.0	sharing	1.0	cardenal	1.0			rectification	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			-urland	1.0	lima	1.0		
+242	unauthorized	3	software park	1.0	holborn london ec1n	1.0			tech zone	1.0	holborn london ec1n	1.0			tech zone	1.0	itv rights limited	1.0			paris france	2.0	-urland	1.0	bueno	1.0			jurisdiction	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			menu	1.0	lion	1.0		
+243	member	3	s	1.0	itv rights limited	1.0			s	1.0	itv rights limited	1.0			owner	1.0	itv consumer limited	1.0			request form	2.0	menu	1.0	monreal	1.0			mail address -email-	1.0	services uk europe	1.0			affiliate	1.0	lion??s	1.0		
+244	resolution	3	owner	1.0	itv consumer limited	1.0			owner	1.0	itv consumer limited	1.0			registry code	1.0	holborn london ec1n	1.0			hn amsterdam	2.0	affiliate	1.0	planta	1.0			receipt	1.0	international dpd	1.0			limitation	1.0	belgium	1.0		
+245	based	3	registry code	1.0	fremantle media limited	1.0			registry code	1.0	fremantle media limited	1.0			unsubscribe option	1.0	stephen street london w1 t	1.0			information collection	2.0	limitation	1.0	chief	1.0			address -email-	1.0	dpd terms	1.0			opposition	1.0	westrem	1.0		
+246	specifically	3	unsubscribe option	1.0	got talent	1.0			unsubscribe option	1.0	waterhouse square	1.0			promotion	1.0	x factor	1.0			instruction	2.0	opposition	1.0	local	1.0			communication feature	1.0	brexit csr press centre	1.0			submission	1.0	denijs	1.0		
+247	local	3	promotion	1.0	waterhouse square	1.0			promotion	1.0	got talent	1.0			offer	1.0	fremantle media limited	1.0			method	2.0	submission	1.0	user	1.0			juvenile	1.0	update	1.0			payment	1.0	sint	1.0		
+248	handle	3	offer	1.0	x factor	1.0			offer	1.0	x factor	1.0			newsletter	1.0	britain	1.0			conduct	2.0	payment	1.0	bank	1.0			blog	1.0	conditions	1.0			gdprbot	1.0	soudanstraat	1.0		
+249	confidentially	3	newsletter	1.0	britain	1.0			newsletter	1.0	britain	1.0			datum use practice	1.0	waterhouse square	1.0			investigate	2.0	voice	1.0	icbc	1.0			forum	1.0	commitment	1.0			person	1.0	octaaf	1.0		
+250	offer	3	datum use practice	1.0	gb	1.0			datum use practice	1.0	gb	1.0			contextlogic use	1.0	gb	1.0			indicate	2.0	gdprbot	1.0	entertainment	1.0			communication option	1.0	apec cbpr	1.0			regulator	1.0	civil	1.0		
+251	encourage	3	contextlogic use	1.0	hydrane sas	1.0			contextlogic use	1.0	hydrane sas	1.0			support ticket	1.0	hydrane sas	1.0			log	2.0	person	1.0	thinking	1.0			decision	1.0	privacyto	1.0			flat	1.0	outfit7	1.0		
+252	quickly	3	support ticket	1.0	denis	1.0			support ticket	1.0	denis	1.0			rectification	1.0	paris	1.0			take-two	2.0	regulator	1.0	ape	1.0			datum request	1.0	apple	1.0			ip	1.0	uber	1.0		
+253	paris	3	rectification	1.0	paris	1.0			rectification	1.0	paris	1.0			jurisdiction	1.0	denis	1.0			internet privacy policy administrator	2.0	flat	1.0	labs	1.0			word	1.0	european data protection officer	1.0			box	1.0	israel	1.0		
+254	amsterdam	3	jurisdiction	1.0	homa games	1.0			jurisdiction	1.0	homa games	1.0			access request	1.0	homa games	1.0			street new york ny	2.0	ip	1.0	planb	1.0			subject	1.0	apples privacy policy	1.0			po	1.0	zone	1.0		
+255	strozzilaan	3	access request	1.0	companyabout games blog jobs	1.0			access request	1.0	companyabout games blog jobs	1.0			mail address -email-	1.0	denis paris france	1.0			erase	2.0	po	1.0	homer	1.0			unsubscribe instruction	1.0	prp	1.0			attention	1.0	industrial	1.0		
+256	barbara	3	mail address -email-	1.0	denis paris france	1.0			mail address -email-	1.0	denis paris france	1.0			receipt	1.0	companyabout games blog jobs	1.0			instance	2.0	box	1.0	park	1.0			ctr	1.0	calabasas rd calabasas	1.0			place	1.0	ayin	1.0		
+257	201	3	receipt	1.0	twitter facebook linkedin	1.0			receipt	1.0	games articles	1.0			address -email-	1.0	games articles	1.0			collect information	2.0	attention	1.0	letsvpn	1.0			customer service email address	1.0	contact	1.0			touch	1.0	ha	1.0		
+258	1083	3	address -email-	1.0	games articles	1.0			address -email-	1.0	twitter facebook linkedin	1.0			communication feature	1.0	rue	1.0			professional	2.0	place	1.0	game	1.0			document	1.0	planetart llc	1.0			compliance	1.0	rosh	1.0		
+259	hn	3	communication feature	1.0	events careers	1.0			communication feature	1.0	events careers	1.0			juvenile	1.0	twitter facebook linkedin	1.0			thomson reuters	2.0	touch	1.0	level	1.0			party tracking	1.0	spotify	1.0			-emailwith	1.0	str	1.0		
+260	relevant	3	juvenile	1.0	rue	1.0			juvenile	1.0	rue	1.0			blog	1.0	events careers	1.0			uk limited	2.0	action	1.0	lima	1.0			advertising	1.0	w 18th street	1.0			login	1.0	internatsionalnaya	1.0		
+261	reason	3	forum	1.0	.california	1.0			blog	1.0	.california	1.0			forum	1.0	.california	1.0			process information	2.0	compliance	1.0	sky	1.0			user content	1.0	new york ny	1.0			dissemination	1.0	masha	1.0		
+262	interactive	3	blog	1.0	tiktok inc	1.0			forum	1.0	tiktok inc	1.0			communication option	1.0	tiktok inc	1.0			question comment complaint	2.0	-emailwith	1.0	lion	1.0			meaning	1.0					aspect	1.0	republic	1.0		
+263	york	3	communication option	1.0	tiktok legal department	1.0			communication option	1.0	venice blvd suite	1.0			decision	1.0	venice blvd suite	1.0			south	2.0	login	1.0	lion??s	1.0			paragraph	1.0					ability	1.0	swag	1.0		
+264	new	3	decision	1.0	venice blvd suite	1.0			decision	1.0	tiktok legal department	1.0			datum request	1.0	tiktok legal department	1.0			offer	2.0	dissemination	1.0	musescore	1.0			privacy concern complaint	1.0					answer	1.0	liability	1.0		
+265	event	3	datum request	1.0	culver city	1.0			datum request	1.0	culver city	1.0			subject	1.0	culver city	1.0			option	2.0	aspect	1.0	denijs	1.0			dispute	1.0					storage	1.0	doubleugames	1.0		
+266	deal	3	subject	1.0	usaemail	1.0			subject	1.0	usaemail	1.0			word	1.0	usaemail	1.0			request contact	2.0	ability	1.0	sint	1.0			connection	1.0					-emailany	1.0	ga	1.0		
+267	store	3	word	1.0	october	1.0			word	1.0	october	1.0			unsubscribe instruction	1.0	october	1.0			privacy policy contact	2.0	answer	1.0	westrem	1.0			request email	1.0					change	1.0	woodstock	1.0		
+268	usa	3	unsubscribe instruction	1.0	bytedance uk limited aviation house	1.0			unsubscribe instruction	1.0	bytedance uk limited aviation house	1.0			ctr	1.0	bytedance uk limited aviation house	1.0			eu representative	2.0	storage	1.0	octaaf	1.0			handling	1.0					companyattn	1.0	ave	1.0		
+269	response	3	ctr	1.0	kingsway holborn london wc2b	1.0			ctr	1.0	kingsway holborn london wc2b	1.0			customer service email address	1.0	kingsway holborn london wc2b	1.0			open	2.0	-emailany	1.0	soudanstraat	1.0			data transfer tool	1.0					material	1.0	aurora	1.0		
+270	30	3	customer service email address	1.0	summarywhat	1.0			customer service email address	1.0	summarywhat	1.0			document	1.0	summarywhat	1.0			request erasure	2.0	change	1.0	belgium	1.0			mail -email-	1.0					deletion	1.0	tastypill	1.0		
+271	head	3	document	1.0	contractual	1.0			document	1.0	contractual	1.0			profile	1.0	contractual	1.0			permit	2.0	companyattn	1.0	civil	1.0			user information	1.0					extent	1.0	testfoni	1.0		
+272	agent	3	profile	1.0	floor millmead guildford surrey england gu2 4hj	1.0			profile	1.0	floor millmead guildford surrey england gu2 4hj	1.0			party tracking	1.0	hays house north wing	1.0			webmartgroup	2.0	material	1.0	outfit7	1.0			function	1.0					withdrawal	1.0	boubolina	1.0		
+273	option	3	party tracking	1.0	hays house north wing	1.0			party tracking	1.0	hays house north wing	1.0			advertising	1.0	floor millmead guildford surrey england gu2 4hj	1.0			llc	2.0	deletion	1.0	kwalee	1.0			institution	1.0					eea	1.0	topface	1.0		
+274	10	3	advertising	1.0	england	1.0			advertising	1.0	england	1.0			user content	1.0	england	1.0			support service	2.0	withdrawal	1.0	uber	1.0			mean	1.0					ec3r	1.0	sunnyvale	1.0		
+275	zuuks	3	user content	1.0	contact information	1.0			user content	1.0	support centre	1.0			meaning	1.0	contact information	1.0			claim arise	2.0	extent	1.0	rosh	1.0			database	1.0					suite	1.0	montgomery	1.0		
+276	erasure	3	meaning	1.0	support centre	1.0			meaning	1.0	contact information	1.0			paragraph	1.0	support centre	1.0			datum breach	2.0	eea	1.0	ha	1.0			member	1.0					interest	1.0	tubi	1.0		
+277	day	3	paragraph	1.0	fireproof	1.0			paragraph	1.0	fireproof	1.0			privacy concern complaint	1.0	fireproof	1.0			mention topic	2.0	ec3r	1.0	industrial	1.0			child user	1.0					volume	1.0	applications	1.0		
+278	remain	3	privacy concern complaint	1.0	data protection team	1.0			privacy concern complaint	1.0	data protection team	1.0			connection	1.0	data protection team	1.0			accident occur	2.0	suite	1.0	zone	1.0			hn	1.0					traffic	1.0	site	1.0		
+279	young	3	dispute	1.0	fireproof studios ltd	1.0			connection	1.0	fireproof studios ltd	1.0			dispute	1.0	fireproof studios ltd	1.0			alexadra games	2.0	interest	1.0	israel	1.0			end	1.0					pattern	1.0	camel	1.0		
+280	stop	3	connection	1.0	sega	1.0			dispute	1.0	sega	1.0			telephone number	1.0	sega	1.0			following contact information	2.0	analytic	1.0	ayin	1.0			question complaint	1.0					sale	1.0	store	1.0		
+281	withdraw	3	telephone number	1.0	batemans row london ec2a	1.0			telephone number	1.0	batemans row london ec2a	1.0			request email	1.0	batemans row london ec2a	1.0			support form	2.0	base	1.0	diandian	1.0			question opinion	1.0					base	1.0	/apple	1.0		
+282	cover	3	request email	1.0	pepper deals ltd	1.0			request email	1.0	pepper deals ltd	1.0			data transfer tool	1.0	pepper deals ltd	1.0			day	2.0	sale	1.0	str	1.0			setting	1.0					analytic	1.0	play	1.0		
+283	disclose	3	data transfer tool	1.0	k?benhavn sor	1.0			data transfer tool	1.0	k?benhavn sor	1.0			handling	1.0	k?benhavn sor	1.0			assistance	2.0	pattern	1.0	republic	1.0			left	1.0					group	1.0	google	1.0		
+284	contain	3	handling	1.0	lindgreens	1.0			handling	1.0	lindgreens	1.0			mail -email-	1.0	lindgreens	1.0			remain	2.0	traffic	1.0	internatsionalnaya	1.0			controller section	1.0					producer	1.0	ellation	1.0		
+285	cyprus	3	mail -email-	1.0	high road east finchley london	1.0			mail -email-	1.0	high road east finchley london	1.0			user information	1.0	high road east finchley london	1.0			request removal	2.0	volume	1.0	liability	1.0			datum privacy practice	1.0					programme	1.0	software	1.0		
+286	activity	3	user information	1.0	restaurants limited customer services	1.0			user information	1.0	restaurants limited customer services	1.0			function	1.0	restaurants limited customer services	1.0			allow	2.0	group	1.0	swag	1.0			option	1.0					ico	1.0	cube	1.0		
+287	commissioner	3	mean	1.0	uk information commissioners office	1.0			function	1.0	uk information commissioners office	1.0			institution	1.0	uk information commissioners office	1.0			withdraw	2.0	producer	1.0	masha	1.0			mind	1.0					experience	1.0	picard	1.0		
+288	base	3	institution	1.0	legal department freeview	1.0			institution	1.0	legal department freeview	1.0			mean	1.0	legal department freeview	1.0			publish	2.0	programme	1.0	doubleugames	1.0			personal information	1.0					publishing	1.0	pierre	1.0		
+289	web	3	function	1.0	floor	1.0			mean	1.0	floor	1.0			database	1.0	floor	1.0			identity	2.0	ico	1.0	ga	1.0			party advertiser	1.0					platform	1.0	dashlane	1.0		
+290	transfer	3	database	1.0	digital uk limited	1.0			database	1.0	dtv services ltd	1.0			child user	1.0	dtv services ltd	1.0			datum processing	2.0	t	1.0	aurora	1.0			partner	1.0					calendar	1.0	duolingo	1.0		
+291	swiss	3	child user	1.0	dtv services ltd	1.0			child user	1.0	digital uk limited	1.0			member	1.0	digital uk limited	1.0			mailing list	2.0	publishing	1.0	ave	1.0			disclosure	1.0					contactquestion	1.0	sweden	1.0		
+292	individual	3	member	1.0	professions code section	1.0			member	1.0	professions code section	1.0			hn	1.0	professions code section	1.0			addition	2.0	experience	1.0	woodstock	1.0			sharing	1.0					residence	1.0	stockholm	1.0		
+293	promotional	3	hn	1.0	california business	1.0			hn	1.0	california business	1.0			end	1.0	picsart inc.	1.0			disclose	2.0	platform	1.0	tastypill	1.0			regulation	1.0					-emailprivacy	1.0	brunnsgatan	1.0		
+294	explain	3	end	1.0	sutter st.	1.0			end	1.0	picsart inc.	1.0			question complaint	1.0	california business	1.0			body	2.0	calendar	1.0	testfoni	1.0			system	1.0					clause	1.0	pvt	1.0		
+295	prevent	3	question complaint	1.0	picsart inc.	1.0			question complaint	1.0	sutter st.	1.0			question opinion	1.0	sutter st.	1.0			explanation	2.0	contactquestion	1.0	boubolina	1.0			-urland	1.0					complaintsin	1.0	technologies	1.0		
+296	misuse	3	question opinion	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			question opinion	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			setting	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			mailing address	2.0	-emailprivacy	1.0	sunnyvale	1.0			party information disclosure	1.0					ground	1.0	gametion	1.0		
+297	reasonable	3	setting	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			setting	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			left	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			support feature	2.0	residence	1.0	tubi	1.0			information processing	1.0					opportunity	1.0	eea	1.0		
+298	saygames	3	left	1.0	brexit csr press centre	1.0			left	1.0	services uk europe	1.0			controller section	1.0	services uk europe	1.0			claim regard	2.0	clause	1.0	montgomery	1.0			security question	1.0					operation	1.0	m	1.0		
+299	password	3	controller section	1.0	services uk europe	1.0			controller section	1.0	dpd terms	1.0			datum privacy practice	1.0	international dpd	1.0			services	2.0	complaintsin	1.0	-emailwith	1.0			game support menu	1.0					step	1.0	ec2	1.0		
+300	compromise	3	datum privacy practice	1.0	international dpd	1.0			datum privacy practice	1.0	international dpd	1.0			personal information	1.0	dpd terms	1.0			processing activity	2.0	ground	1.0	adobe	1.0			affiliate	1.0					unit	1.0	liverpool	1.0		
+301	inform	3	party advertiser	1.0	dpd terms	1.0			party advertiser	1.0	brexit csr press centre	1.0			party advertiser	1.0	brexit csr press centre	1.0			follow apply	2.0	opportunity	1.0	site	1.0			datum information	1.0					recipient	1.0	gogogame	1.0		
+302	apple	3	personal information	1.0	update	1.0			personal information	1.0	conditions	1.0			mind	1.0	conditions	1.0			following information	2.0	operation	1.0	applications	1.0			datum rectification	1.0					beginning	1.0	shepherds	1.0		
+303	choice	3	option	1.0	conditions	1.0			partner	1.0	update	1.0			option	1.0	update	1.0			understand	2.0	step	1.0	camel	1.0			limitation	1.0					language	1.0	w14	1.0		
+304	headspace	3	partner	1.0	european data protection officer	1.0			mind	1.0	european data protection officer	1.0			partner	1.0	european data protection officer	1.0			set	2.0	unit	1.0	app	1.0			opposition	1.0					subscription	1.0	charecroft	1.0		
+305	disable	3	mind	1.0	apples privacy policy	1.0			option	1.0	apples privacy policy	1.0			disclosure	1.0	apples privacy policy	1.0			support page	2.0	recipient	1.0	store	1.0			submission	1.0					fax	1.0	way	1.0		
+306	homa	3	disclosure	1.0	apec cbpr	1.0			disclosure	1.0	apec cbpr	1.0			sharing	1.0	apec cbpr	1.0			customer service channel	2.0	beginning	1.0	play	1.0			payment information	1.0					minor	1.0	central	1.0		
+307	protect	3	sharing	1.0	prp	1.0			sharing	1.0	prp	1.0			regulation	1.0	prp	1.0			client	2.0	language	1.0	/apple	1.0			party company	1.0					circumstance	1.0	building	1.0		
+308	sega	3	regulation	1.0	commitment	1.0			regulation	1.0	commitment	1.0			-urland	1.0	commitment	1.0			information concern	2.0	subscription	1.0	ellation	1.0			-url- user	1.0					push	1.0	catch	1.0		
+309	spotify	3	-urland	1.0	privacyto	1.0			-urland	1.0	privacyto	1.0			party information disclosure	1.0	privacyto	1.0			in-game	2.0	fax	1.0	cube	1.0			data protection practice	1.0					sms	1.0	good	1.0		
+310	keyword	2	party information disclosure	1.0	apple support	1.0			party information disclosure	1.0	apple support	1.0			information processing	1.0	apple support	1.0			telemarketing	2.0	minor	1.0	software	1.0			controller	1.0					asset	1.0	rijk	1.0		
+311	add	2	information processing	1.0	calabasas rd calabasas	1.0			information processing	1.0	calabasas rd calabasas	1.0			security question	1.0	calabasas rd calabasas	1.0			endeavour	2.0	push	1.0	dashlane	1.0			support center	1.0					seller	1.0	schiphol	1.0		
+312	available	2	security question	1.0	planetart llc	1.0			security question	1.0	planetart llc	1.0			game support menu	1.0	planetart llc	1.0			following email address	2.0	sms	1.0	pierre	1.0			data policy	1.0					buyer	1.0	beechavenue	1.0		
+313	external	2	game support menu	1.0	customer care	1.0			game support menu	1.0	customer care	1.0			affiliate	1.0	customer care	1.0			address set	2.0	circumstance	1.0	picard	1.0			gdprbot	1.0					duty	1.0	900san	1.0		
+314	entity	2	affiliate	1.0	customer support	1.0			affiliate	1.0	customer support	1.0			datum information	1.0	customer support	1.0			privacy shield policy	2.0	asset	1.0	dingtone	1.0			person	1.0					obligation	1.0	officerone	1.0		
+315	alternative	2	datum information	1.0	spotify	1.0			datum information	1.0	spotify	1.0			datum rectification	1.0	spotify	1.0			satisfaction	2.0	seller	1.0	duolingo	1.0			protection	1.0					agreement	1.0	cumberland	1.0		
+316	nature	2	datum rectification	1.0	w 18th street	1.0			datum rectification	1.0	new york ny	1.0			limitation	1.0	new york ny	1.0			acknowledgment	2.0	buyer	1.0	sweden	1.0			building flat	1.0					property	1.0	place	1.0		
+317	infringe	2	submission	1.0	new york ny	1.0			submission	1.0	w 18th street	1.0			opposition	1.0	w 18th street	1.0			tantan	2.0	agreement	1.0	stockholm	1.0			regulator	1.0					policythis	1.0	fenian	1.0		
+318	emailso	2	limitation	1.0					opposition	1.0					submission	1.0					email contain	2.0	duty	1.0	brunnsgatan	1.0			security measure	1.0					parcel	1.0	streetdublin	1.0		
+319	violate	2	opposition	1.0					limitation	1.0					party company	1.0					prevent misuse	2.0	obligation	1.0	gamegos	1.0			ip address	1.0					point	1.0	ireland	1.0		
+320	work	2	party company	1.0					party company	1.0					payment information	1.0					-emailalong	2.0	property	1.0	gametion	1.0			-emailor po box	1.0					surcharge	1.0	tricor	1.0		
+321	regulation	2	payment information	1.0					payment information	1.0					-url- user	1.0					passport	2.0	policythis	1.0	technologies	1.0			attention	1.0					fuel	1.0	mark	1.0		
+322	scope	2	-url- user	1.0					-url- user	1.0					data protection practice	1.0					delete user provide datum	2.0	point	1.0	pvt	1.0			place	1.0					schedule	1.0	saygames	1.0		
+323	visitor	2	data protection practice	1.0					data protection practice	1.0					voice	1.0					purpose	2.0	parcel	1.0	eea	1.0			privacy question concern	1.0					sitemap	1.0	cookie	1.0		
+324	particulary	2	voice	1.0					voice	1.0					support center	1.0					system	2.0	pickup	1.0	m	1.0			privacy inquiry form	1.0					award	1.0	britbox	1.0		
+325	respective	2	support center	1.0					support center	1.0					data policy	1.0					department	2.0	schedule	1.0	liverpool	1.0			touch	1.0					career	1.0	addressable	1.0		
+326	testimonial	2	data policy	1.0					data policy	1.0					gdprbot	1.0					rooster teeth productions llc	2.0	award	1.0	ec2	1.0			compliance	1.0					franchise	1.0	square	1.0		
+327	profile	2	gdprbot	1.0					gdprbot	1.0					protection	1.0					legal department	2.0	career	1.0	gogogame	1.0			-emailwith	1.0					vacancy	1.0	waterhouse	1.0		
+328	800	2	protection	1.0					protection	1.0					person	1.0					request question	2.0	vacancy	1.0	shepherds	1.0			login	1.0					postcode	1.0	ec1n	1.0		
+329	1800	2	person	1.0					person	1.0					building flat	1.0					saygames	2.0	surcharge	1.0	w14	1.0			information collection	1.0					phishing	1.0	consumer	1.0		
+330	007	2	building flat	1.0					building flat	1.0					regulator	1.0					-url-	2.0	franchise	1.0	good	1.0			dissemination practice	1.0					moment	1.0	gb	1.0		
+331	related	2	regulator	1.0					regulator	1.0					security measure	1.0					stay	2.0	sitemap	1.0	catch	1.0			aspect	1.0					certification	1.0	media	1.0		
+332	high	2	security measure	1.0					security measure	1.0					ip address	1.0					belarus minsk	2.0	moment	1.0	building	1.0			ability	1.0					guideline	1.0	fremantle	1.0		
+333	efta	2	ip address	1.0					ip address	1.0					-emailor po box	1.0					read	2.0	certification	1.0	central	1.0			datum collection	1.0					employee	1.0	stephen	1.0		
+334	economic	2	-emailor po box	1.0					-emailor po box	1.0					attention	1.0					invoke	2.0	guideline	1.0	charecroft	1.0			processing practice	1.0					download	1.0	factor	1.0		
+335	area	2	attention	1.0					attention	1.0					contact email	1.0					visit feedback page	2.0	employee	1.0	way	1.0			security violation	1.0					region	1.0	x	1.0		
+336	france	2	contact email	1.0					contact email	1.0					place	1.0					datum controller	2.0	region	1.0	schiphol	1.0			-emailor	1.0					restriction	1.0	talent	1.0		
+337	rue	2	place	1.0					place	1.0					privacy question concern	1.0					twitter international company	2.0	download	1.0	rijk	1.0			storage	1.0					control	1.0	got	1.0		
+338	75010	2	privacy question concern	1.0					privacy question concern	1.0					privacy inquiry form	1.0					contact twitter	2.0	restriction	1.0	beechavenue	1.0			-emailany time	1.0					limit	1.0	britain	1.0		
+339	method	2	privacy inquiry form	1.0					privacy inquiry form	1.0					touch	1.0					yumobi tekhnolodzhi ooo support service	2.0	limit	1.0	ireland	1.0			datum privacy inquiry	1.0					exercise	1.0	hydrane	1.0		
+340	conduct	2	touch	1.0					touch	1.0					action	1.0					assist	2.0	exercise	1.0	900san	1.0			information request	1.0							linkedin	1.0		
+341	investigate	2	action	1.0					action	1.0					compliance	1.0					search	2.0	control	1.0	cumberland	1.0			website account	1.0							facebook	1.0		
+342	indicate	2	compliance	1.0					compliance	1.0					login	1.0					share information	2.0			place	1.0			business purpose	1.0							jobs	1.0		
+343	line	2	-emailwith	1.0					login	1.0					-emailwith	1.0					ensure	2.0			fenian	1.0			question query	1.0							blog	1.0		
+344	social	2	login	1.0					-emailwith	1.0					information collection	1.0					communication	2.0			tricor	1.0			update	1.0							careers	1.0		
+345	log	2	dissemination practice	1.0					dissemination practice	1.0					dissemination practice	1.0					obtain removal	2.0			mark	1.0			contact e	1.0							articles	1.0		
+346	unable	2	information collection	1.0					information collection	1.0					aspect	1.0					contact headspace	2.0			direct	1.0			information practice	1.0							events	1.0		
+347	point	2	aspect	1.0					aspect	1.0					ability	1.0					technology	2.0			britbox	1.0			privacy policy change	1.0							companyabout	1.0		
+348	internet	2	ability	1.0					ability	1.0					datum collection	1.0					cookie policy	2.0			addressable	1.0			notification	1.0							city	1.0		
+349	44th	2	security violation	1.0					security violation	1.0					processing practice	1.0					product	2.0			waterhouse	1.0			companyattn	1.0							usaemail	1.0		
+350	110	2	datum collection	1.0					processing practice	1.0					security violation	1.0					information commissioner	2.0			square	1.0			material	1.0							culver	1.0		
+351	10036	2	processing practice	1.0					datum collection	1.0					-emailor	1.0					company number	2.0			ec1n	1.0			unsubscribe	1.0							blvd	1.0		
+352	inaccurate	2	-emailor	1.0					-emailor	1.0					answer	1.0					vat registration number	2.0			factor	1.0			communication	1.0							venice	1.0		
+353	erase	2	answer	1.0					answer	1.0					storage	1.0					homa	2.0			consumer	1.0			deletion	1.0							october	1.0		
+354	software	2	storage	1.0					storage	1.0					-emailany time	1.0					business	2.0			x	1.0			withdrawal	1.0							wc2b	1.0		
+355	zone	2	-emailany time	1.0					-emailany time	1.0					datum privacy inquiry	1.0					telephone	2.0			fremantle	1.0			extent	1.0							summarywhat	1.0		
+356	park	2	datum privacy inquiry	1.0					datum privacy inquiry	1.0					information request	1.0					sega europe limited customer services	2.0			britain	1.0			agent question comment	1.0							kingsway	1.0		
+357	instance	2	information request	1.0					information request	1.0					website account	1.0					country	2.0			got	1.0			eea	1.0							aviation	1.0		
+358	device	2	website account	1.0					website account	1.0					business purpose	1.0					address telephone number	2.0			talent	1.0			customer support	1.0							bytedance	1.0		
+359	professional	2	business purpose	1.0					business purpose	1.0					question query	1.0					email address provide	2.0			stephen	1.0			agent	1.0							4hj	1.0		
+360	canary	2	question query	1.0					question query	1.0					update	1.0					mcdonald	2.0			gb	1.0			suite	1.0							gu2	1.0		
+361	wharf	2	update	1.0					update	1.0					contact e	1.0					privacy matter	2.0			media	1.0			ec3r	1.0							england	1.0		
+362	colonnade	2	contact e	1.0					contact e	1.0					privacy policy change	1.0					spotify usa inc	2.0			hydrane	1.0			interest	1.0							surrey	1.0		
+363	e14	2	privacy policy change	1.0					privacy policy change	1.0					information practice	1.0					privacy office	2.0			blog	1.0			activity	1.0							guildford	1.0		
+364	94104	2	information practice	1.0					information practice	1.0					notification	1.0					singapore	1.0			linkedin	1.0			user base sale pattern traffic volume	1.0							millmead	1.0		
+365	2nd	2	notification	1.0					notification	1.0					companyattn	1.0					govern	1.0			facebook	1.0			analytic	1.0							wing	1.0		
+366	code	2	companyattn	1.0					companyattn	1.0					material	1.0					request describe	1.0			articles	1.0			group company	1.0							north	1.0		
+367	contextlogic	2	unsubscribe	1.0					material	1.0					unsubscribe	1.0					datum protection officer	1.0			events	1.0			company number	1.0							hays	1.0		
+368	permit	2	material	1.0					unsubscribe	1.0					deletion	1.0					detail set	1.0			careers	1.0			producer	1.0							ec2a	1.0		
+369	emailto	2	deletion	1.0					deletion	1.0					extent	1.0					entity	1.0			jobs	1.0			programme	1.0							row	1.0		
+370	open	2	extent	1.0					extent	1.0					withdrawal	1.0					jagex limited	1.0			companyabout	1.0			ico	1.0							batemans	1.0		
+371	94103	2	withdrawal	1.0					withdrawal	1.0					agent question comment	1.0					-emailor send	1.0			.california	1.0			privacy query	1.0							deals	1.0		
+372	clarification	2	agent question comment	1.0					agent question comment	1.0					eea	1.0					hold information	1.0			october	1.0			game support	1.0							pepper	1.0		
+373	webmartgroup	2	eea	1.0					eea	1.0					customer support	1.0					child age	1.0			venice	1.0			policy term	1.0							sor	1.0		
+374	arise	2	customer support	1.0					customer support	1.0					suite	1.0					send email	1.0			blvd	1.0			publishing	1.0							k?benhavn	1.0		
+375	present	2	ec3r	1.0					suite	1.0					ec3r	1.0					contact lingodeer	1.0			culver	1.0			experience	1.0							lindgreens	1.0		
+376	breach	2	suite	1.0					ec3r	1.0					activity	1.0					consider	1.0			city	1.0			calendar year	1.0							mcdonald	1.0		
+377	accident	2	interest	1.0					activity	1.0					interest	1.0					designated countriemay	1.0			usaemail	1.0			platform	1.0							finchley	1.0		
+378	occur	2	activity	1.0					interest	1.0					user base sale pattern traffic volume	1.0					choose exit	1.0			bytedance	1.0			marketing use	1.0							east	1.0		
+379	topic	2	user base sale pattern traffic volume	1.0					user base sale pattern traffic volume	1.0					analytic	1.0					datum protection law	1.0			aviation	1.0			contactquestion comment	1.0							high	1.0		
+380	alexadra	2	analytic	1.0					analytic	1.0					group company	1.0					general data protection regulation	1.0			kingsway	1.0			-emailprivacy	1.0							restaurants	1.0		
+381	blog	2	group company	1.0					group company	1.0					producer	1.0					member state	1.0			wc2b	1.0			residence	1.0							freeview	1.0		
+382	allow	2	programme	1.0					producer	1.0					programme	1.0					portal	1.0			summarywhat	1.0			representative	1.0							digital	1.0		
+383	long	2	producer	1.0					programme	1.0					ico	1.0					datum protection regulation	1.0			contractual	1.0			complaintsin	1.0							dtv	1.0		
+384	publish	2	ico	1.0					ico	1.0					privacy query	1.0					objection	1.0			4hj	1.0			support request	1.0							section	1.0		
+385	identity	2	privacy query	1.0					privacy query	1.0					game support	1.0					e-mail address provide	1.0			gu2	1.0			communication preference	1.0							professions	1.0		
+386	future	2	policy term	1.0					game support	1.0					policy term	1.0					email preference	1.0			hays	1.0			opportunity	1.0							business	1.0		
+387	addition	2	game support	1.0					policy term	1.0					publishing	1.0					unsubscribe link find	1.0			north	1.0			authority	1.0							st.	1.0		
+388	explanation	2	experience	1.0					publishing	1.0					experience	1.0					discontinue receive	1.0			wing	1.0			operation	1.0							sutter	1.0		
+389	301	2	publishing	1.0					experience	1.0					calendar year	1.0					member profile	1.0			millmead	1.0			step	1.0							picsart	1.0		
+390	able	2	marketing use	1.0					calendar year	1.0					platform	1.0					customer support team	1.0			guildford	1.0			unit	1.0							1by.you	1.0		
+391	nicosia	2	calendar year	1.0					platform	1.0					marketing use	1.0					feedback	1.0			surrey	1.0			recipient	1.0							dpdgroup	1.0		
+392	avenue	2	platform	1.0					marketing use	1.0					contactquestion comment	1.0					support widget	1.0			pepper	1.0			beginning	1.0							dpd	1.0		
+393	understand	2	contactquestion comment	1.0					contactquestion comment	1.0					-emailprivacy	1.0					related entity	1.0			deals	1.0			contact form	1.0							press	1.0		
+394	microsoft	2	residence	1.0					residence	1.0					residence	1.0					incur	1.0			batemans	1.0			language website	1.0							csr	1.0		
+395	trustarc	2	-emailprivacy	1.0					-emailprivacy	1.0					clause	1.0					mobile	1.0			row	1.0			subscription feature	1.0							products	1.0		
+396	identifiable	2	clause	1.0					clause	1.0					complaintsin	1.0					pay phone	1.0			ec2a	1.0			datum controller	1.0							brexit	1.0		
+397	client	2	complaintsin	1.0					complaintsin	1.0					ground	1.0					metro customer service number	1.0			lindgreens	1.0			email phone fax	1.0							1by	1.0		
+398	channel	2	ground	1.0					ground	1.0					support request	1.0					principle	1.0			k?benhavn	1.0			minor	1.0							conditions	1.0		
+399	telemarketing	2	support request	1.0					support request	1.0					communication preference	1.0					dot	1.0			sor	1.0			measure	1.0							update	1.0		
+400	postal	2	communication preference	1.0					communication preference	1.0					opportunity	1.0					com	1.0			high	1.0			email sms push notification	1.0							privacyto	1.0		
+401	endeavour	2	opportunity	1.0					opportunity	1.0					operation	1.0					contact twitters data protection officer	1.0			restaurants	1.0			circumstance	1.0							apples	1.0		
+402	4th	2	step	1.0					operation	1.0					step	1.0					time contact	1.0			east	1.0			asset	1.0							commitment	1.0		
+403	play	2	operation	1.0					step	1.0					unit	1.0					suggestion concern data protection	1.0			finchley	1.0			customer	1.0							prp	1.0		
+404	studios	2	unit	1.0					unit	1.0					recipient	1.0					europe	1.0			freeview	1.0			seller	1.0							cbpr	1.0		
+405	lion	2	recipient	1.0					recipient	1.0					beginning	1.0					contact information provide	1.0			dtv	1.0			buyer	1.0							apec	1.0		
+406	shield	2	beginning	1.0					beginning	1.0					contact form	1.0					contact information offer	1.0			digital	1.0			right property	1.0							apple	1.0		
+407	acknowledgment	2	contact form	1.0					contact form	1.0					language website	1.0					data manager contact information section	1.0			sutter	1.0			duty	1.0							calabasas	1.0		
+408	timely	2	language website	1.0					language website	1.0					subscription feature	1.0					datum protection	1.0			st.	1.0			obligation	1.0							rd	1.0		
+409	satisfaction	2	subscription feature	1.0					subscription feature	1.0					privacy statement	1.0					reply	1.0			business	1.0			agreement	1.0							planetart	1.0		
+410	tantan	2	privacy statement	1.0					privacy statement	1.0					email phone fax	1.0					service feel	1.0			professions	1.0			issue concern	1.0							care	1.0		
+411	disclosure	2	email phone fax	1.0					email phone fax	1.0					minor	1.0					find contact detail	1.0			section	1.0			privacy policythis policy	1.0							18th	1.0		
+412	passport	2	measure	1.0					minor	1.0					measure	1.0					data protection authority	1.0			picsart	1.0			driver	1.0										
+413	emailalong	2	minor	1.0					measure	1.0					email sms push notification	1.0					-emailor send mail	1.0			dpdgroup	1.0			delivery point	1.0										
+414	fast	2	email sms push notification	1.0					email sms push notification	1.0					circumstance	1.0					rules	1.0			1by.you	1.0			parcel	1.0										
+415	google	2	circumstance	1.0					circumstance	1.0					asset	1.0					condition	1.0			dpd	1.0			pickup service update delivery schedule	1.0										
+416	rooster	2	right property	1.0					asset	1.0					right property	1.0					following link	1.0			1by	1.0			vacancy owner driver franchise service	1.0										
+417	austin	2	customer	1.0					right property	1.0					customer	1.0					relive	1.0			products	1.0			cookie policy phishing data protection	1.0										
+418	tx	2	asset	1.0					customer	1.0					seller	1.0					help page	1.0			update	1.0			technology security career	1.0										
+419	51st	2	agreement	1.0					agreement	1.0					duty	1.0					data protection officer know	1.0			brexit	1.0			sitemap fuel surcharge	1.0										
+420	productions	2	obligation	1.0					obligation	1.0					buyer	1.0					skg	1.0			csr	1.0			postcode	1.0										
+421	1901	2	seller	1.0					buyer	1.0					obligation	1.0					help	1.0			press	1.0			award	1.0										
+422	78723	2	duty	1.0					seller	1.0					agreement	1.0					datum want	1.0			conditions	1.0			moment	1.0										
+423	stay	2	buyer	1.0					duty	1.0					issue concern	1.0					storytel process	1.0			apec	1.0			privacy safeguard	1.0										
+424	belarus	2	issue concern	1.0					issue concern	1.0					privacy policythis policy	1.0					merchandise relate	1.0			cbpr	1.0			privacy law	1.0										
+425	minsk	2	privacy policythis policy	1.0					privacy policythis policy	1.0					delivery point	1.0					example	1.0			prp	1.0			security guideline	1.0										
+426	carefully	2	delivery point	1.0					delivery point	1.0					driver	1.0					marketing preference	1.0			commitment	1.0			certification	1.0										
+427	read	2	driver	1.0					parcel	1.0					parcel	1.0					social club	1.0			privacyto	1.0			employee	1.0										
+428	emailany	2	parcel	1.0					driver	1.0					pickup service update delivery schedule	1.0					email -emailfrom	1.0			calabasas	1.0			breach	1.0										
+429	invoke	2	pickup service update delivery schedule	1.0					pickup service update delivery schedule	1.0					vacancy owner driver franchise service	1.0					email account	1.0			rd	1.0			region	1.0										
+430	topface	2	vacancy owner driver franchise service	1.0					vacancy owner driver franchise service	1.0					cookie policy phishing data protection	1.0					join social club include	1.0			planetart	1.0			download request	1.0										
+431	commissioners	2	cookie policy phishing data protection	1.0					cookie policy phishing data protection	1.0					technology security career	1.0					social club nickname	1.0			care	1.0			mobile app	1.0										
+432	measure	2	technology security career	1.0					technology security career	1.0					postcode	1.0					field	1.0			18th	1.0			restriction	1.0										
+433	ooo	2	sitemap fuel surcharge	1.0					sitemap fuel surcharge	1.0					award	1.0					social point hold	1.0							-emailor assistance	1.0										
+434	yumobi	2	postcode	1.0					postcode	1.0					sitemap fuel surcharge	1.0					social point mailing list	1.0							center	1.0										
+435	tekhnolodzhi	2	award	1.0					award	1.0					moment	1.0					646-536-2842	1.0							age limit	1.0										
+436	assist	2	moment	1.0					moment	1.0					privacy safeguard	1.0					prof	1.0							control section	1.0										
+437	good	2	privacy safeguard	1.0					privacy safeguard	1.0					privacy law	1.0					use tandem	1.0							exercise	1.0										
+438	sas	2	privacy law	1.0					privacy law	1.0					security guideline	1.0					-phoneor	1.0							information cookie	1.0										
+439	legitimate	2	security guideline	1.0					security guideline	1.0					certification	1.0					zone chengdu sichuan china	1.0																		
+440	eea	2	breach	1.0					certification	1.0					employee	1.0					endeavor	1.0																		
+441	centre	2	certification	1.0					employee	1.0					breach	1.0					ted	1.0																		
+442	50	2	employee	1.0					breach	1.0					download request	1.0					ted sites	1.0																		
+443	notification	2	download request	1.0					download request	1.0					region	1.0					contact ted	1.0																		
+444	lane	2	region	1.0					region	1.0					mobile app	1.0					information collect process use	1.0																		
+445	suite	2	mobile app	1.0					mobile app	1.0					restriction	1.0					store	1.0																		
+446	emailin	2	restriction	1.0					restriction	1.0					-emailor assistance	1.0					owner	1.0																		
+447	similar	2	-emailor assistance	1.0					-emailor assistance	1.0					center	1.0					tile device	1.0																		
+448	technology	2	center	1.0					center	1.0					age limit	1.0					privacy team	1.0																		
+449	product	2	control section	1.0					age limit	1.0					control section	1.0					privacy team thomson reuters	1.0																		
+450	itv	2	age limit	1.0					control section	1.0					exercise	1.0					escalate	1.0																		
+451	vat	2	exercise	1.0					exercise	1.0					information cookie	1.0					data protection officer thomson reuters	1.0																		
+452	w1t	2	information cookie	1.0					information cookie	1.0											twitch services	1.0																		
+453	0041	2																			bush street	1.0																		
+454	76	2																			vertigo games sepapaja	1.0																		
+455	tiktok	2																			tallinn	1.0																		
+456	england	2																			estonia registry code	1.0																		
+457	fireproof	2																			restrict	1.0																		
+458	brentford	2																			designate agent	1.0																		
+459	845	2																			receive email	1.0																		
+460	5502	2																			promotion	1.0																		
+461	14	2																			newsletter	1.0																		
+462	country	2																			datum use practice	1.0																		
+463	mcdonald	2																			email address list	1.0																		
+464	3jf	2																			section contact	1.0																		
+465	mortimer	2																			games	1.0																		
+466	dpdgroup	2																			-emailto request access	1.0																		
+467	b66	2																			port	1.0																		
+468	delivery	2																			support ticket	1.0																		
+469	driver	2																			seek rectification	1.0																		
+470	governance	2																			information hold	1.0																		
+471	management	2																			zuuks games	1.0																		
+472	grci	2																			jurisdiction	1.0																		
+473	lagavooren	2																			contact zuuks games	1.0																		
+474	boyne	2																			link send e-mail	1.0																		
+475	drawer	2																			contact zynga	1.0																		
+476	suntec	1																			customer support page	1.0																		
+477	singapore	1																			access request	1.0																		
+478	038988	1																			request concern	1.0																		
+479	temasek	1																			clarification musixmatch	1.0																		
+480	08	1																			provide e-mail	1.0																		
+481	05	1																			receipt	1.0																		
+482	boulevard	1																			aim	1.0																		
+483	govern	1																			zacna	1.0																		
+484	oversee	1																			street	1.0																		
+485	jagex	1																			gdask poland	1.0																		
+486	particular	1																			stop use	1.0																		
+487	kindly	1																			erasure	1.0																		
+488	lingodeer	1																			communication feature	1.0																		
+489	consider	1																			contact camsurf	1.0																		
+490	countriemay	1																			juvenile	1.0																		
+491	designated	1																			define	1.0																		
+492	exit	1																			require age	1.0																		
+493	choose	1																			forum	1.0																		
+494	portal	1																			blog	1.0																		
+495	national	1																			decision	1.0																		
+496	objection	1																			communication option update	1.0																		
+497	discontinue	1																			possess	1.0																		
+498	freedom	1																			collect use	1.0																		
+499	3979	1																			datum request	1.0																		
+500	clara	1																			subject	1.0																		
+501	santa	1																			word	1.0																		
+502	95054	1																			instruction contain	1.0																		
+503	circle	1																			california	1.0																		
+504	12th	1																			customer service email address	1.0																		
+505	widget	1																			think clicktouch games	1.0																		
+506	cost	1																			abide	1.0																		
+507	992	1																			post privacy policy	1.0																		
+508	1300	1																			dvloper	1.0																		
+509	pay	1																			dvapps ab	1.0																		
+510	363	1																			oval	1.0																		
+511	incur	1																			krinou street	1.0																		
+512	metro	1																			easybrain ltd	1.0																		
+513	principle	1																			limassol cyprus	1.0																		
+514	adopt	1																			accommodate	1.0																		
+515	interested	1																			redirect	1.0																		
+516	mondly	1																			address provide	1.0																		
+517	com	1																			document feel	1.0																		
+518	dot	1																			stakhanovskaya	1.0																		
+519	twitters	1																			technopark perm	1.0																		
+520	11	1																			profile	1.0																		
+521	manager	1																			question regard view	1.0																		
+522	reply	1																			tracking	1.0																		
+523	primarily	1																			advertising	1.0																		
+524	petites	1																			alert	1.0																		
+525	ecuries	1																			request relate	1.0																		
+526	des	1																			146-148 strovolos avenue petousis building	1.0																		
+527	rules	1																			strovolos nicosia cyprus	1.0																		
+528	condition	1																			commissioner	1.0																		
+529	relive	1																			personal data protection	1.0																		
+530	skg	1																			realise	1.0																		
+531	youd	1																			planta	1.0																		
+532	0161	1																			sevilla	1.0																		
+533	1162	1																			sevilla spain	1.0																		
+534	768	1																			user content	1.0																		
+535	storytel	1																			eu resident	1.0																		
+536	merchandise	1																			information ask question	1.0																		
+537	example	1																			meaning	1.0																		
+538	2k	1																			privacy policy access	1.0																		
+539	club	1																			paragraph	1.0																		
+540	join	1																			datum base	1.0																		
+541	emailfrom	1																			eu data protection officer	1.0																		
+542	nickname	1																			microsoft chief privacy officer	1.0																		
+543	field	1																			privacy concern complaint	1.0																		
+544	2842	1																			trustarc	1.0																		
+545	536	1																			connection	1.0																		
+546	646	1																			resolve dispute	1.0																		
+547	regular	1																			contact trustarc	1.0																		
+548	eprivacy	1																			telephone number	1.0																		
+549	gmbh	1																			request email	1.0																		
+550	represent	1																			data transfer tool	1.0																		
+551	prof	1																			handling	1.0																		
+552	tandem	1																			eu local representative	1.0																		
+553	dont	1																			user information policy	1.0																		
+554	tap4fun	1																			function	1.0																		
+555	tianfu	1																			bank	1.0																		
+556	chengdu	1																			icbc	1.0																		
+557	sichuan	1																			user information	1.0																		
+558	china	1																			institution	1.0																		
+559	emailvia	1																			mean	1.0																		
+560	tech	1																			mention	1.0																		
+561	phoneor	1																			come	1.0																		
+562	0086	1																			privacy policy email	1.0																		
+563	a3	1																			thinking ape entertainment ltd	1.0																		
+564	endeavor	1																			planb labs	1.0																		
+565	ted	1																			database	1.0																		
+566	sites	1																			stop collect	1.0																		
+567	tile	1																			child user	1.0																		
+568	2121	1																			member	1.0																		
+569	mateo	1																			-emailor write	1.0																		
+570	94403	1																			homer	1.0																		
+571	camino	1																			locate	1.0																		
+572	900	1																			park avenue south	1.0																		
+573	escalate	1																			floor ny ny	1.0																		
+574	satisfied	1																			amsterdam	1.0																		
+575	5ep	1																			-urlor	1.0																		
+576	twitch	1																			play	1.0																		
+577	bush	1																			end	1.0																		
+578	350	1																			question complaint	1.0																		
+579	registry	1																			contact level	1.0																		
+580	14340159	1																			contact lima sky	1.0																		
+581	vertigo	1																			contact lion studios	1.0																		
+582	15551	1																			suggestion concern	1.0																		
+583	estonia	1																			question opinion	1.0																		
+584	tallinn	1																			left	1.0																		
+585	sepapaja	1																			setting-feedback	1.0																		
+586	restrict	1																			forward	1.0																		
+587	designate	1																			welcome feedback	1.0																		
+588	newsletter	1																			following address	1.0																		
+589	promotion	1																			information provide	1.0																		
+590	special	1																			data controller section	1.0																		
+591	electronic	1																			datum privacy practice	1.0																		
+592	commercial	1																			advertiser	1.0																		
+593	ticket	1																			mind	1.0																		
+594	port	1																			partner	1.0																		
+595	jurisdiction	1																			stop	1.0																		
+596	zynga	1																			prefer	1.0																		
+597	699	1																			use musescore	1.0																		
+598	8th	1																			sint-denijs-westrem	1.0																		
+599	physical	1																			octaaf soudanstraat	1.0																		
+600	musixmatch	1																			belgium	1.0																		
+601	statutory	1																			entitled	1.0																		
+602	receipt	1																			prevent disclosure	1.0																		
+603	aim	1																			california civil code section	1.0																		
+604	quote	1																			ur contact information	1.0																		
+605	effectively	1																			sharing	1.0																		
+606	just	1																			regulation	1.0																		
+607	zacna	1																			age specify	1.0																		
+608	poland	1																			party information collection	1.0																		
+609	gdask	1																			party information disclosure	1.0																		
+610	283	1																			outfit7	1.0																		
+611	80	1																			information processing	1.0																		
+612	traditional	1																			security question	1.0																		
+613	unanswered	1																			privacy policy notice	1.0																		
+614	thereof	1																			enquiry regard	1.0																		
+615	camsurf	1																			support menu	1.0																		
+616	yo	1																			right set	1.0																		
+617	juvenile	1																			act accord	1.0																		
+618	legally	1																			kwalee	1.0																		
+619	define	1																			affiliate	1.0																		
+620	forum	1																			registered office	1.0																		
+621	decision	1																			datum information	1.0																		
+622	possess	1																			include access	1.0																		
+623	bluehole	1																			limitation	1.0																		
+624	pnix	1																			opposition	1.0																		
+625	body	1																			datum rectification	1.0																		
+626	word	1																			submission	1.0																		
+627	seek	1																			transfer datum	1.0																		
+628	lockhart	1																			store use	1.0																		
+629	chai	1																			payment information	1.0																		
+630	wan	1																			google	1.0																		
+631	ro	1																			-url- user	1.0																		
+632	rm	1																			personal datum	1.0																		
+633	307	1																			data protection practice	1.0																		
+634	19c	1																			diandian	1.0																		
+635	ctr	1																			love hear	1.0																		
+636	clicktouch	1																			voice	1.0																		
+637	abide	1																			microsoft welcome	1.0																		
+638	dvapps	1																			adhere	1.0																		
+639	dvloper	1																			privacy feedback	1.0																		
+640	ab	1																			limited liability company swag masha	1.0																		
+641	easybrain	1																			republic	1.0																		
+642	limassol	1																			internatsionalnaya str	1.0																		
+643	4103	1																			service remain	1.0																		
+644	oval	1																			personal information	1.0																		
+645	krinou	1																			doubleugames account	1.0																		
+646	6th	1																			-emailany time	1.0																		
+647	emailhowever	1																			aurora ave woodstock ga	1.0																		
+648	redirect	1																			data policy	1.0																		
+649	accommodate	1																			gdprbot	1.0																		
+650	preferred	1																			testfoni	1.0																		
+651	document	1																			information apply	1.0																		
+652	technopark	1																			datum topface send	1.0																		
+653	stakhanovskaya	1																			protection	1.0																		
+654	perm	1																			person	1.0																		
+655	54	1																			information commissioners	1.0																		
+656	advertising	1																			boubolina building	1.0																		
+657	tracking	1																			nicosia cyprus	1.0																		
+658	alert	1																			topface	1.0																		
+659	strovolos	1																			regulator	1.0																		
+660	petousis	1																			security measure	1.0																		
+661	146	1																			track	1.0																		
+662	148	1																			ip address	1.0																		
+663	2048	1																			help solve	1.0																		
+664	incorrect	1																			-emailor po box	1.0																		
+665	realise	1																			attention	1.0																		
+666	sevilla	1																			california privacy rights	1.0																		
+667	spain	1																			privacy tubi inc	1.0																		
+668	genera	1																			twitter inc	1.0																		
+669	cardenal	1																			yumobi tekhnolodzhi ooo	1.0																		
+670	planta	1																			compromise	1.0																		
+671	monreal	1																			information relate	1.0																		
+672	bueno	1																			place	1.0																		
+673	41010	1																			service wish	1.0																		
+674	20	1																			review information collect	1.0																		
+675	permanently	1																			information modify	1.0																		
+676	meaning	1																			fill	1.0																		
+677	paragraph	1																			privacy question concern	1.0																		
+678	chief	1																			privacy inquiry form	1.0																		
+679	connection	1																			adobe	1.0																		
+680	3995	1																			touch	1.0																		
+681	82	1																			action	1.0																		
+682	1588	1																			perform	1.0																		
+683	handling	1																			compliance	1.0																		
+684	tool	1																			information handle	1.0																		
+685	icbc	1																			disclose information	1.0																		
+686	function	1																			review delete	1.0																		
+687	institution	1																			follow address	1.0																		
+688	overseas	1																			identifying information	1.0																		
+689	bank	1																			email include	1.0																		
+690	mean	1																			dissemination practice	1.0																		
+691	come	1																			site applications	1.0																		
+692	watchdog	1																			camel games	1.0																		
+693	ape	1																			aspect	1.0																		
+694	thinking	1																			app store	1.0																		
+695	entertainment	1																			google play	1.0																		
+696	planb	1																			browse	1.0																		
+697	labs	1																			tap	1.0																		
+698	database	1																			scroll	1.0																		
+699	emailuse	1																			contact information list	1.0																		
+700	homer	1																			exercise choice	1.0																		
+701	460	1																			ability	1.0																		
+702	10016	1																			follow mailing address	1.0																		
+703	south	1																			market st	1.0																		
+704	letsvpn	1																			data cube software collect	1.0																		
+705	personally	1																			good	1.0																		
+706	level	1																			dashlane sas	1.0																		
+707	lima	1																			rue pierre picard	1.0																		
+708	sky	1																			need assistance	1.0																		
+709	opinion	1																			security violation	1.0																		
+710	various	1																			datum collection	1.0																		
+711	left	1																			processing practice	1.0																		
+712	setting	1																			answer	1.0																		
+713	forward	1																			storage	1.0																		
+714	advertiser	1																			dingtone	1.0																		
+715	partner	1																			-urlor -emailany time	1.0																		
+716	mind	1																			-emailto	1.0																		
+717	far	1																			contact duolingo	1.0																		
+718	prefer	1																			datum privacy inquiry	1.0																		
+719	musescore	1																			information request	1.0																		
+720	belgium	1																			direct	1.0																		
+721	octaaf	1																			brunnsgatan	1.0																		
+722	soudanstraat	1																			stockholm sweden	1.0																		
+723	denijs	1																			discuss	1.0																		
+724	9051	1																			claim	1.0																		
+725	22	1																			question express	1.0																		
+726	westrem	1																			gamegos	1.0																		
+727	sint	1																			user want	1.0																		
+728	civil	1																			complain	1.0																		
+729	1798	1																			gametion technologies pvt ltd	1.0																		
+730	83	1																			website account	1.0																		
+731	furthermore	1																			deactivate	1.0																		
+732	ur	1																			retain	1.0																		
+733	sharing	1																			-emailbut note	1.0																		
+734	specify	1																			business purpose	1.0																		
+735	urland	1																			eea resident	1.0																		
+736	outfit7	1																			dpo centre	1.0																		
+737	menu	1																			gogogame	1.0																		
+738	act	1																			change update	1.0																		
+739	accord	1																			question query	1.0																		
+740	kwalee	1																			contact e-mail address	1.0																		
+741	uber	1																			schiphol-rijk	1.0																		
+742	affiliate	1																			beechavenue	1.0																		
+743	israel	1																			data privacy officer	1.0																		
+744	515059236	1																			privacy policy change	1.0																		
+745	rosh	1																			-email- notification	1.0																		
+746	ayin	1																			reflect change	1.0																		
+747	industrial	1																			information practice	1.0																		
+748	ha	1																			twitter international companyattn	1.0																		
+749	submission	1																			d02 ax07 ireland	1.0																		
+750	rectification	1																			cancel email	1.0																		
+751	limitation	1																			material	1.0																		
+752	opposition	1																			deletion	1.0																		
+753	payment	1																			withdrawal	1.0																		
+754	diandian	1																			extent	1.0																		
+755	hear	1																			post content	1.0																		
+756	voice	1																			identify	1.0																		
+757	love	1																			eea register agent question comment	1.0																		
+758	connected	1																			reach headspace customer support	1.0																		
+759	adhere	1																			tricor suite 4th floor	1.0																		
+760	practically	1																			mark lane london	1.0																		
+761	liability	1																			tricor	1.0																		
+762	internatsionalnaya	1																			7qr	1.0																		
+763	masha	1																			registered agent	1.0																		
+764	republic	1																			-emailin order	1.0																		
+765	220030	1																			complaint saygames	1.0																		
+766	swag	1																			saygames llc address	1.0																		
+767	str	1																			involve	1.0																		
+768	terms	1																			activity set	1.0																		
+769	doubleugames	1																			interest	1.0																		
+770	30188	1																			display	1.0																		
+771	woodstock	1																			process base	1.0																		
+772	302	1																			service-specific privacy notice	1.0																		
+773	aurora	1																			registered email address	1.0																		
+774	ga	1																			itv group company	1.0																		
+775	ave	1																			addressable platform limited	1.0																		
+776	tastypill	1																			britbox	1.0																		
+777	gdprbot	1																			united kingdom	1.0																		
+778	testfoni	1																			ico website	1.0																		
+779	authorized	1																			register office	1.0																		
+780	person	1																			holborn london ec1n 2ae	1.0																		
+781	regulator	1																			waterhouse square	1.0																		
+782	lead	1																			itv rights limited	1.0																		
+783	flat	1																			relate	1.0																		
+784	main	1																			britain	1.0																		
+785	1060	1																			got talent	1.0																		
+786	40	1																			itv consumer limited	1.0																		
+787	boubolina	1																			fremantle media limited	1.0																		
+788	ip	1																			programme act	1.0																		
+789	track	1																			producer	1.0																		
+790	solve	1																			vat registration number gb	1.0																		
+791	sunnyvale	1																			privacy query	1.0																		
+792	94088	1																			paris	1.0																		
+793	60429	1																			faubourg saint-denis	1.0																		
+794	po	1																			datum collect	1.0																		
+795	box	1																			hydrane sas	1.0																		
+796	rights	1																			data processing concern	1.0																		
+797	tubi	1																			contact homa games section	1.0																		
+798	montgomery	1																			close publishing	1.0																		
+799	attention	1																			search hit enter	1.0																		
+800	315	1																			esc	1.0																		
+801	international	1																			faubourg saint-denis paris france	1.0																		
+802	outside	1																			game support	1.0																		
+803	shall	1																			condition twitter facebook linkedin search	1.0																		
+804	place	1																			rue	1.0																		
+805	adobe	1																			use cookie	1.0																		
+806	touch	1																			business relate enquiry	1.0																		
+807	perform	1																			experience	1.0																		
+808	action	1																			calendar year	1.0																		
+809	compliance	1																			residentsonce	1.0																		
+810	login	1																			entitle	1.0																		
+811	identifying	1																			obtain information	1.0																		
+812	dissemination	1																			marketing use	1.0																		
+813	applications	1																			recommend	1.0																		
+814	camel	1																			tiktok inc	1.0																		
+815	aspect	1																			tiktok legal department	1.0																		
+816	browse	1																			venice blvd suite	1.0																		
+817	tap	1																			october 2019welcome	1.0																		
+818	search	1																			tiktok	1.0																		
+819	scroll	1																			usaemail address	1.0																		
+820	ellation	1																			residence	1.0																		
+821	market	1																			bytedance uk limited aviation house	1.0																		
+822	835	1																			kingsway holborn london wc2b	1.0																		
+823	cube	1																			agree	1.0																		
+824	dashlane	1																			upload content	1.0																		
+825	75018	1																			create	1.0																		
+826	21	1																			privacy policy click	1.0																		
+827	pierre	1																			clause	1.0																		
+828	picard	1																			complaintsin	1.0																		
+829	answer	1																			email protect	1.0																		
+830	dingtone	1																			england	1.0																		
+831	storage	1																			company registered	1.0																		
+832	duolingo	1																			protect	1.0																		
+833	556895	1																			committed	1.0																		
+834	1213	1																			process contact information	1.0																		
+835	brunnsgatan	1																			support request	1.0																		
+836	stockholm	1																			-emailin accordance	1.0																		
+837	sweden	1																			support centre	1.0																		
+838	111	1																			use agree	1.0																		
+839	38	1																			fireproof	1.0																		
+840	discuss	1																			talk	1.0																		
+841	gamegos	1																			za055154	1.0																		
+842	express	1																			data protection team	1.0																		
+843	complain	1																			fireproof studios ltd	1.0																		
+844	gametion	1																			question feel	1.0																		
+845	pvt	1																			confirm	1.0																		
+846	technologies	1																			opportunity	1.0																		
+847	deactivate	1																			communication preference	1.0																		
+848	retain	1																			sign	1.0																		
+849	emailbut	1																			device	1.0																		
+850	liverpool	1																			interact	1.0																		
+851	797	1																			sega learn	1.0																		
+852	6340	1																			step	1.0																		
+853	7pr	1																			operation sega	1.0																		
+854	203	1																			pepper deals ltd unit	1.0																		
+855	ec2m	1																			batemans row london	1.0																		
+856	gogogame	1																			3hh	1.0																		
+857	shepherds	1																			detail regard	1.0																		
+858	catch	1																			recipient	1.0																		
+859	w14	1																			beginning	1.0																		
+860	0ee	1																			language website	1.0																		
+861	beechavenue	1																			lindgreens	1.0																		
+862	rijk	1																			contact form	1.0																		
+863	schiphol	1																			mail address	1.0																		
+864	1119	1																			opt-out instruction	1.0																		
+865	182	1																			subscription feature	1.0																		
+866	accurate	1																			opt-in	1.0																		
+867	ensure	1																			elect	1.0																		
+868	reflect	1																			receive marketing communication	1.0																		
+869	companyattn	1																			uk information commissioners office	1.0																		
+870	inquiry1355	1																			follow detail	1.0																		
+871	streetdublin	1																			legal department freeview 2nd floor	1.0																		
+872	ireland	1																			dtv services ltd	1.0																		
+873	officerone	1																			registration number z9156270 act	1.0																		
+874	d02	1																			digital uk limited	1.0																		
+875	cancel	1																			email phone fax	1.0																		
+876	select	1																			reset	1.0																		
+877	material	1																			account compromise	1.0																		
+878	deletion	1																			advise	1.0																		
+879	withdrawal	1																			misuse	1.0																		
+880	extent	1																			minor	1.0																		
+881	identify	1																			professions code section	1.0																		
+882	855	1																			email -emailor contact	1.0																		
+883	432	1																			california business	1.0																		
+884	3822	1																			registered user	1.0																		
+885	tricor	1																			email sms push notification	1.0																		
+886	ec3r	1																			circumstance require	1.0																		
+887	7qr	1																			customer	1.0																		
+888	mark	1																			apply	1.0																		
+889	ul	1																			enforce	1.0																		
+890	involve	1																			comply	1.0																		
+891	instal	1																			buy	1.0																		
+892	traffic	1																			asset	1.0																		
+893	sale	1																			obligation	1.0																		
+894	analytic	1																			sell	1.0																		
+895	britbox	1																			seller	1.0																		
+896	addressable	1																			buyer	1.0																		
+897	group	1																			agreement	1.0																		
+898	emailmake	1																			issue concern	1.0																		
+899	clear	1																			attempt	1.0																		
+900	britain	1																			re-deliver	1.0																		
+901	programme	1																			driver	1.0																		
+902	producer	1																			delivery point	1.0																		
+903	media	1																			parcel	1.0																		
+904	06633451	1																			return	1.0																		
+905	consumer	1																			deliver	1.0																		
+906	factor	1																			dpd	1.0																		
+907	ec1n	1																			conditions privacy	1.0																		
+908	197	1																			uk delivery	1.0																		
+909	67	1																			cookie policy phishing data protection	1.0																		
+910	hydrane	1																			postcode affect	1.0																		
+911	faubourg	1																			dpd terms	1.0																		
+912	publishing	1																			gdpr sitemap fuel surcharge	1.0																		
+913	companyabout	1																			services uk europe	1.0																		
+914	facebook	1																			familiarize	1.0																		
+915	01	1																			moment	1.0																		
+916	residentsonce	1																			security guideline	1.0																		
+917	calendar	1																			datum use concern regard	1.0																		
+918	recommend	1																			communicate	1.0																		
+919	contactquestion	1																			prp certification	1.0																		
+920	informed	1																			apec cbpr	1.0																		
+921	residence	1																			apple employee	1.0																		
+922	city	1																			dispute resolution	1.0																		
+923	usaemail	1																			commitment	1.0																		
+924	venice	1																			apples privacy policy	1.0																		
+925	emailprivacy	1																			european data protection officer	1.0																		
+926	10100	1																			enforce privacy safeguard	1.0																		
+927	2019welcome	1																			breach	1.0																		
+928	blvd	1																			information receive	1.0																		
+929	bytedance	1																			triage	1.0																		
+930	aviation	1																			team	1.0																		
+931	summarywhat	1																			apple support number	1.0																		
+932	wc2b	1																			above-mention right	1.0																		
+933	upload	1																			planetart llc	1.0																		
+934	contractual	1																			restriction	1.0																		
+935	clause	1																			customer care department use	1.0																		
+936	standard	1																			object	1.0																		
+937	complaintsin	1																			access rectify	1.0																		
+938	thorough	1																			contact customer support	1.0																		
+939	hays	1																			-emailor assistance	1.0																		
+940	guildford	1																			term use	1.0																		
+941	surrey	1																			clarification	1.0																		
+942	house	1																			data protection officer use	1.0																		
+943	millmead	1																			spotify	1.0																		
+944	north	1																			control section	1.0																		
+945	ground	1																			request exercise	1.0																		
+946	wing	1																			age limit	1.0																		
+947	gu2	1																			new york ny	1.0																		
+948	4hj	1																			hope	1.0																		
+949	06687549	1																			enjoy spotify	1.0																		
+950	committed	1																			street floor	1.0																		
+951	properly	1																			contact customer service	1.0																		
+952	agree	1																			information cookie	1.0																		
+953	talk	1																			authenticate	1.0																		
+954	za055154	1																			fulfil	1.0																		
+955	sign	1																			safety	1.0																		
+956	middlesex	1																																						
+957	confirm	1																																						
+958	west	1																																						
+959	opportunity	1																																						
+960	____________________________________________________________________	1																																						
+961	interact	1																																						
+962	supervisory	1																																						
+963	children	1																																						
+964	unhappy	1																																						
+965	pepper	1																																						
+966	deals	1																																						
+967	ec2a	1																																						
+968	3hh	1																																						
+969	row	1																																						
+970	batemans	1																																						
+971	unit	1																																						
+972	recipient	1																																						
+973	beginning	1																																						
+974	lindgreens	1																																						
+975	37561304	1																																						
+976	language	1																																						
+977	benhavn	1																																						
+978	2300	1																																						
+979	electronically	1																																						
+980	sor	1																																						
+981	subscription	1																																						
+982	elect	1																																						
+983	subsequently	1																																						
+984	restaurants	1																																						
+985	finchley	1																																						
+986	59	1																																						
+987	2018	1																																						
+988	road	1																																						
+989	n2	1																																						
+990	freeview	1																																						
+991	27	1																																						
+992	dtv	1																																						
+993	digital	1																																						
+994	z9156270	1																																						
+995	z7207230	1																																						
+996	fax	1																																						
+997	reset	1																																						
+998	advise	1																																						
+999	emailthat	1																																						
+1000	minor	1																																						
+1001	valid	1																																						
+1002	picsart	1																																						
+1003	publicly	1																																						
+1004	22581	1																																						
+1005	211	1																																						
+1006	sms	1																																						
+1007	push	1																																						
+1008	circumstance	1																																						
+1009	property	1																																						
+1010	acquire	1																																						
+1011	obligation	1																																						
+1012	asset	1																																						
+1013	buyer	1																																						
+1014	sell	1																																						
+1015	seller	1																																						
+1016	additionally	1																																						
+1017	smethwick	1																																						
+1018	1by	1																																						
+1019	roebuck	1																																						
+1020	policythis	1																																						
+1021	urlto	1																																						
+1022	deliver	1																																						
+1023	parcel	1																																						
+1024	return	1																																						
+1025	usif	1																																						
+1026	early	1																																						
+1027	dpd	1																																						
+1028	postcode	1																																						
+1029	pickup	1																																						
+1030	surcharge	1																																						
+1031	brexit	1																																						
+1032	fuel	1																																						
+1033	schedule	1																																						
+1034	familiarize	1																																						
+1035	moment	1																																						
+1036	privacyto	1																																						
+1037	apec	1																																						
+1038	apples	1																																						
+1039	prp	1																																						
+1040	secure	1																																						
+1041	cbpr	1																																						
+1042	certification	1																																						
+1043	guideline	1																																						
+1044	companywide	1																																						
+1045	download	1																																						
+1046	region	1																																						
+1047	triage	1																																						
+1048	planetart	1																																						
+1049	calabasas	1																																						
+1050	91302	1																																						
+1051	rectify	1																																						
+1052	restriction	1																																						
+1053	care	1																																						
+1054	control	1																																						
+1055	enjoy	1																																						
+1056	45	1																																						
+1057	18th	1																																						
+1058	10011	1																																						
+1059	hope	1																																						
+1060	authenticate	1																																						
+1061	safety	1																																						
+1062	fulfil	1																																						

--- a/event_extraction/output/user_rights_sentences_single_keywords.csv
+++ b/event_extraction/output/user_rights_sentences_single_keywords.csv
@@ -1,0 +1,1930 @@
+	KeyBert	KeyBert_Freq	TextRank_NOUN	TextRank_NOUN_Freq	TextRank_PROPN	TextRank_PROPN_Freq	TextRank_VERB	TextRank_VERB_Freq	SingleRank_NOUN	SingleRank_NOUN_Freq	SingleRank_PROPN	SingleRank_PROPN_Freq	SingleRank_VERB	SingleRank_VERB_Freq	PositionRank_NOUN	PositionRank_NOUN_Freq	PositionRank_PROPN	PositionRank_PROPN_Freq	PositionRank_VERB	PositionRank_VERB_Freq	MultipartiteRank	MultipartiteRank_Freq	Yake_NOUN	Yake_NOUN_Freq	Yake_PROPN	Yake_PROPN_Freq	Yake_VERB	Yake_VERB_Freq	sCAKE_NOUN	sCAKE_NOUN_Freq	sCAKE_PROPN	sCAKE_PROPN_Freq	sCAKE_VERB	sCAKE_VERB_Freq	SGRank_NOUN	SGRank_NOUN_Freq	SGRank_PROPN	SGRank_PROPN_Freq	SGRank_VERB	SGRank_VERB_Freq
+0	personal	813.0	right	672.0	privacy policy	132.0	contact	573.0	right	672.0	privacy policy	132.0	contact	573.0	right	672.0	privacy policy	132.0	contact	573.0	right	546	right	686.0	privacy	176.0	contact	571.0	right	527.0	privacy policy	25.0	contact	237.0	right	658.0	privacy	168.0	contact	383.0
+1	information	694.0	information	592.0	gdpr	75.0	request	249.0	information	592.0	gdpr	75.0	request	249.0	information	592.0	gdpr	75.0	request	249.0	contact	534	information	662.0	policy	146.0	request	249.0	information	449.0	gdpr	24.0	delete	163.0	information	610.0	policy	141.0	request	226.0
+2	right	686.0	datum	549.0	personal	33.0	delete	233.0	datum	549.0	personal	33.0	delete	233.0	datum	549.0	personal	33.0	delete	233.0	information	522	datum	613.0	data	102.0	delete	245.0	datum	434.0	data protection officer	24.0	request	152.0	datum	575.0	data	93.0	delete	222.0
+3	datum	610.0	question	256.0	article	29.0	provide	185.0	question	256.0	article	29.0	provide	185.0	question	256.0	article	29.0	provide	185.0	datum	462	question	292.0	gdpr	76.0	provide	185.0	processing	223.0	general data protection regulation	11.0	provide	148.0	processing	272.0	protection	71.0	provide	180.0
+4	contact	605.0	processing	244.0	data protection officer	24.0	object	172.0	processing	244.0	data protection officer	24.0	object	172.0	processing	244.0	data protection officer	24.0	object	172.0	request	257	processing	275.0	protection	71.0	object	177.0	question	180.0	european economic area	11.0	process	117.0	question	255.0	gdpr	51.0	process	162.0
+5	email	496.0	time	146.0	personal data	17.0	process	143.0	time	146.0	personal data	17.0	process	143.0	time	146.0	personal data	17.0	process	143.0	use	252	data	175.0	personal	71.0	process	164.0	time	131.0	united kingdom	10.0	access	87.0	data	175.0	personal	44.0	access	150.0
+6	request	356.0	complaint	139.0	personal information	17.0	access	135.0	complaint	139.0	personal information	17.0	access	135.0	complaint	139.0	personal information	17.0	access	135.0	question	219	account	160.0	information	46.0	access	157.0	complaint	124.0	article	7.0	object	81.0	account	156.0	information	35.0	object	129.0
+7	use	291.0	copy	111.0	information	16.0	ask	106.0	copy	111.0	information	16.0	ask	106.0	copy	112.0	information	16.0	ask	106.0	processing	200	time	147.0	officer	33.0	correct	108.0	copy	97.0	eu	7.0	ask	78.0	time	148.0	officer	32.0	hold	106.0
+8	question	290.0	request	107.0	eu	16.0	hold	106.0	request	107.0	eu	16.0	hold	106.0	email	109.0	eu	16.0	hold	106.0	delete	191	complaint	145.0	article	29.0	ask	106.0	request	94.0	office	7.0	hold	67.0	complaint	138.0	article	29.0	ask	100.0
+9	processing	274.0	account	102.0	data	13.0	restrict	94.0	email	107.0	data	13.0	restrict	94.0	request	107.0	data	13.0	restrict	94.0	object	186	service	130.0	eu	24.0	hold	106.0	use	92.0	data protection authority	6.0	correct	66.0	service	130.0	european	20.0	correct	100.0
+10	privacy	266.0	email	101.0	general data protection regulation	11.0	correct	94.0	account	102.0	general data protection regulation	11.0	correct	94.0	account	103.0	general data protection regulation	11.0	correct	94.0	email	163	email	127.0	european	20.0	restrict	98.0	service	88.0	united states	6.0	receive	65.0	email	121.0	eu	19.0	update	90.0
+11	data	261.0	service	99.0	european economic area	11.0	lodge	86.0	service	99.0	european economic area	11.0	lodge	86.0	service	99.0	european economic area	11.0	lodge	86.0	privacy policy	160	request	124.0	limited	17.0	update	93.0	account	81.0	ico	5.0	use	61.0	request	120.0	limited	17.0	restrict	83.0
+12	delete	247.0	use	97.0	eea	10.0	send	85.0	use	97.0	eea	10.0	send	85.0	use	97.0	eea	10.0	send	85.0	access	148	privacy	112.0	authority	16.0	lodge	86.0	email	81.0	switzerland	5.0	wish	60.0	copy	112.0	authority	16.0	exercise	77.0
+13	access	239.0	access	78.0	privacy	10.0	exercise	82.0	access	78.0	privacy	10.0	exercise	82.0	access	79.0	privacy	10.0	exercise	82.0	time	133	copy	112.0	united	15.0	send	85.0	authority	73.0	personal	5.0	send	60.0	privacy	111.0	united	15.0	receive	77.0
+14	policy	222.0	authority	77.0	united kingdom	10.0	receive	78.0	authority	77.0	united kingdom	10.0	receive	78.0	authority	77.0	united kingdom	10.0	receive	78.0	provide	125	authority	100.0	games	14.0	exercise	83.0	concern	66.0	information commissioner	5.0	exercise	59.0	use	106.0	games	14.0	use	73.0
+15	object	190.0	-email-	76.0	ico	8.0	use	75.0	concern	69.0	ico	8.0	use	75.0	concern	69.0	ico	8.0	use	75.0	complaint	117	use	92.0	state	13.0	receive	79.0	access	65.0	terms	4.0	update	58.0	authority	100.0	support	13.0	send	71.0
+16	provide	184.0	concern	69.0	uber	8.0	update	73.0	-email-	66.0	uber	8.0	update	73.0	-email-	66.0	uber	8.0	update	73.0	copy	109	access	90.0	support	13.0	use	72.0	consent	61.0	eea	4.0	want	58.0	access	90.0	office	12.0	wish	69.0
+17	process	166.0	consent	65.0	art	7.0	wish	69.0	consent	65.0	art	7.0	wish	69.0	consent	65.0	art	7.0	wish	69.0	process	103	-email-	86.0	street	13.0	wish	69.0	user	57.0	member state	4.0	collect	57.0	setting	83.0	street	12.0	collect	66.0
+18	account	163.0	user	61.0	data protection	7.0	collect	64.0	user	61.0	data protection	7.0	collect	64.0	user	61.0	data protection	7.0	change	65.0	ask	102	setting	84.0	office	12.0	collect	66.0	-email-	54.0	netherlands	4.0	like	56.0	protection	82.0	regulation	11.0	want	63.0
+19	protection	147.0	format	55.0	european union	7.0	change	64.0	machine	53.0	european union	7.0	change	64.0	machine	52.0	european union	7.0	collect	64.0	account	100	protection	82.0	twitter	12.0	change	65.0	machine	52.0	data protection supervisory authority	4.0	change	55.0	policy	82.0	general	11.0	change	61.0
+20	complaint	145.0	machine	53.0	office	7.0	want	63.0	child	51.0	office	7.0	want	63.0	child	51.0	office	7.0	want	63.0	lodge	84	policy	82.0	regulation	11.0	want	63.0	accordance	45.0	eu member state	4.0	restrict	54.0	concern	81.0	area	11.0	like	60.0
+21	time	139.0	child	51.0	dpo	6.0	email	62.0	law	47.0	dpo	6.0	email	62.0	section	47.0	dpo	6.0	email	62.0	service	81	concern	81.0	general	11.0	email	62.0	section	45.0	dpo	4.0	believe	47.0	-email-	79.0	economic	11.0	believe	58.0
+22	correct	134.0	law	47.0	data protection authority	6.0	like	60.0	section	47.0	data protection authority	6.0	like	60.0	policy	47.0	data protection authority	6.0	like	60.0	exercise	79	address	80.0	customer	11.0	like	60.0	child	45.0	information commissioners office	3.0	include	45.0	purpose	78.0	london	11.0	email	57.0
+23	concern	133.0	section	47.0	united states	6.0	believe	58.0	policy	47.0	united states	6.0	believe	58.0	law	46.0	united states	6.0	believe	58.0	authority	76	purpose	78.0	google	11.0	believe	58.0	law	43.0	uk	3.0	base	38.0	address	75.0	uk	10.0	erase	54.0
+24	service	133.0	policy	47.0	california	6.0	concern	52.0	format	45.0	california	6.0	concern	52.0	restriction	46.0	california	6.0	concern	52.0	send	76	user	75.0	economic	11.0	base	55.0	format	42.0	union	3.0	email	38.0	user	75.0	state	10.0	base	52.0
+25	update	124.0	accordance	45.0	policy	6.0	erase	52.0	accordance	45.0	policy	6.0	erase	52.0	accordance	45.0	policy	6.0	erase	52.0	hold	73	consent	67.0	area	11.0	erase	55.0	circumstance	40.0	efta states	3.0	remove	37.0	consent	67.0	union	10.0	include	52.0
+26	authority	116.0	restriction	45.0	doubleugames	6.0	obtain	49.0	restriction	45.0	doubleugames	6.0	obtain	49.0	erasure	44.0	doubleugames	6.0	obtain	49.0	receive	70	controller	63.0	london	11.0	concern	53.0	ground	40.0	barbara strozzilaan	3.0	concern	36.0	controller	62.0	kingdom	10.0	concern	49.0
+27	copy	110.0	erasure	44.0	twitter	6.0	include	47.0	erasure	44.0	twitter	6.0	include	47.0	format	44.0	twitter	6.0	include	47.0	correct	70	section	61.0	eea	10.0	include	53.0	purpose	40.0	san francisco	3.0	erase	35.0	section	61.0	ltd	10.0	follow	48.0
+28	ask	104.0	ground	43.0	duolingo	6.0	base	46.0	circumstance	42.0	duolingo	6.0	base	46.0	circumstance	42.0	duolingo	6.0	base	46.0	wish	67	contact	59.0	uk	10.0	obtain	49.0	restriction	38.0	zuuks games	3.0	follow	32.0	contact	59.0	customer	9.0	lodge	47.0
+29	restrict	101.0	circumstance	42.0	state	5.0	remove	45.0	ground	42.0	state	5.0	remove	45.0	ground	42.0	state	5.0	remove	45.0	gdpr	67	law	58.0	union	10.0	follow	48.0	erasure	37.0	privacy shield	3.0	relate	30.0	law	58.0	supervisory	9.0	remove	46.0
+30	hold	101.0	purpose	41.0	switzerland	5.0	relate	43.0	purpose	41.0	switzerland	5.0	relate	43.0	purpose	41.0	switzerland	5.0	relate	43.0	change	63	marketing	58.0	kingdom	10.0	remove	46.0	interest	37.0	uber	3.0	obtain	30.0	marketing	58.0	member	8.0	relate	42.0
+31	address	93.0	address	40.0	information commissioner	5.0	follow	43.0	address	40.0	information commissioner	5.0	follow	43.0	address	40.0	information commissioner	5.0	follow	43.0	restrict	61	format	56.0	california	10.0	relate	43.0	policy	34.0	california	3.0	store	29.0	machine	53.0	google	8.0	obtain	41.0
+32	certain	90.0	way	39.0	terms	4.0	rectify	37.0	way	39.0	terms	4.0	rectify	37.0	way	39.0	terms	4.0	rectify	37.0	update	60	machine	53.0	ltd	10.0	rectify	43.0	article	33.0	privacy statement	3.0	lodge	29.0	portability	52.0	states	8.0	review	37.0
+33	regard	90.0	interest	39.0	member state	4.0	withdraw	36.0	interest	39.0	member state	4.0	withdraw	36.0	interest	38.0	member state	4.0	withdraw	36.0	want	60	portability	52.0	services	10.0	modify	38.0	way	33.0	personal information	3.0	share	29.0	child	52.0	llc	8.0	modify	37.0
+34	exercise	87.0	rectification	34.0	netherlands	4.0	write	36.0	mail	34.0	netherlands	4.0	write	36.0	rectification	34.0	netherlands	4.0	write	36.0	consent	60	child	52.0	ico	9.0	review	37.0	age	32.0	twitter international company	3.0	require	28.0	practice	50.0	california	8.0	rectify	33.0
+35	lodge	85.0	article	33.0	data protection supervisory authority	4.0	store	33.0	article	33.0	data protection supervisory authority	4.0	store	33.0	article	33.0	data protection supervisory authority	4.0	store	33.0	format	59	restriction	50.0	supervisory	9.0	withdraw	36.0	party	31.0	european union	3.0	withdraw	27.0	restriction	49.0	center	8.0	store	33.0
+36	supervisory	84.0	data portability	33.0	facebook	4.0	share	33.0	data portability	33.0	facebook	4.0	share	33.0	data portability	33.0	facebook	4.0	share	33.0	concern	57	practice	50.0	dpo	8.0	write	36.0	privacy policy	31.0	platform	3.0	review	26.0	interest	49.0	services	7.0	share	33.0
+37	send	84.0	data	33.0	llc	4.0	require	31.0	data	33.0	llc	4.0	require	31.0	data	33.0	llc	4.0	require	31.0	believe	57	interest	49.0	member	8.0	store	33.0	deletion	31.0	privacy center	3.0	write	25.0	erasure	48.0	twitter	7.0	write	33.0
+38	setting	83.0	deletion	33.0	webmartgroup	4.0	modify	30.0	rectification	33.0	webmartgroup	4.0	modify	30.0	deletion	33.0	webmartgroup	4.0	modify	30.0	like	56	erasure	48.0	states	8.0	share	33.0	address	30.0	singapore	2.0	submit	23.0	accordance	45.0	ico	6.0	withdraw	31.0
+39	change	80.0	party	32.0	eu member state	4.0	review	29.0	deletion	33.0	eu member state	4.0	review	29.0	party	32.0	eu member state	4.0	review	29.0	user	52	detail	48.0	llc	8.0	require	31.0	data portability	30.0	privacy	2.0	know	22.0	detail	44.0	inc	6.0	require	29.0
+40	receive	78.0	age	32.0	services	4.0	submit	28.0	party	32.0	services	4.0	submit	28.0	mail	32.0	services	4.0	submit	28.0	child	48	accordance	45.0	center	8.0	submit	28.0	data	30.0	advertising demand partner	2.0	log	20.0	format	43.0	inc.	6.0	transmit	27.0
+41	gdpr	76.0	privacy policy	31.0	privacy shield	4.0	transmit	28.0	age	32.0	privacy shield	4.0	transmit	28.0	age	32.0	privacy shield	4.0	transmit	28.0	erase	47	party	43.0	uber	8.0	transmit	28.0	marketing purpose	29.0	publisher partner	2.0	need	20.0	party	43.0	commissioner	6.0	know	26.0
+42	user	76.0	mail	30.0	google	4.0	limit	26.0	privacy policy	31.0	google	4.0	limit	26.0	privacy policy	31.0	google	4.0	limit	26.0	data protection officer	45	rectification	43.0	art	7.0	edit	27.0	rectification	27.0	paris france	2.0	transmit	20.0	circumstance	42.0	dpo	6.0	submit	25.0
+43	purpose	75.0	controller	29.0	dingtone	4.0	know	26.0	controller	29.0	dingtone	4.0	know	26.0	controller	29.0	dingtone	4.0	know	26.0	erasure	44	comment	43.0	inc	6.0	limit	26.0	basis	27.0	hn amsterdam	2.0	modify	20.0	rectification	42.0	eea	5.0	limit	24.0
+44	consent	71.0	marketing purpose	29.0	email	3.0	log	24.0	marketing purpose	29.0	email	3.0	log	24.0	marketing purpose	29.0	email	3.0	log	24.0	accordance	43	circumstance	42.0	europe	6.0	know	26.0	case	27.0	w 44th street new york ny	2.0	rectify	19.0	ground	42.0	terms	5.0	log	24.0
+45	wish	69.0	website	29.0	information commissioners office	3.0	opt	24.0	website	29.0	information commissioners office	3.0	opt	24.0	website	29.0	information commissioners office	3.0	opt	24.0	purpose	42	ground	42.0	inc.	6.0	opt	25.0	privacy	27.0	interactive	2.0	let	18.0	comment	42.0	commissioners	5.0	feel	23.0
+46	legal	68.0	basis	27.0	uk	3.0	feel	23.0	basis	28.0	uk	3.0	feel	23.0	basis	27.0	uk	3.0	feel	23.0	policy	42	deletion	41.0	facebook	6.0	log	24.0	controller	26.0	usa	2.0	limit	17.0	deletion	41.0	switzerland	5.0	need	22.0
+47	make	67.0	case	27.0	union	3.0	need	22.0	case	27.0	union	3.0	need	22.0	case	27.0	union	3.0	need	22.0	address	42	way	39.0	commissioner	6.0	feel	23.0	website	26.0	thomson reuters	2.0	resolve	17.0	way	38.0	netherlands	5.0	opt	22.0
+48	collect	66.0	privacy	27.0	jaumo	3.0	reach	22.0	privacy	27.0	jaumo	3.0	reach	22.0	privacy	27.0	jaumo	3.0	reach	22.0	law	41	mail	38.0	legal	6.0	need	22.0	setting	26.0	uk limited	2.0	describe	16.0	support	38.0	san	5.0	edit	21.0
+49	want	63.0	setting	27.0	lingodeer	3.0	resolve	22.0	setting	27.0	lingodeer	3.0	resolve	22.0	setting	27.0	lingodeer	3.0	resolve	22.0	article	39	support	38.0	doubleugames	6.0	reach	22.0	app	26.0	professional	2.0	stop	14.0	page	36.0	reuters	5.0	stop	21.0
+50	section	63.0	app	27.0	u.s.-based	3.0	describe	21.0	app	27.0	u.s.-based	3.0	describe	21.0	app	27.0	u.s.-based	3.0	describe	21.0	collect	39	page	36.0	duolingo	6.0	resolve	22.0	mail	24.0	south colonnade	2.0	note	14.0	app	35.0	thomson	5.0	describe	21.0
+51	controller	63.0	detail	25.0	efta states	3.0	find	20.0	detail	25.0	efta states	3.0	find	20.0	detail	25.0	efta states	3.0	find	20.0	remove	37	app	35.0	terms	5.0	stop	21.0	account setting	23.0	-emailor	2.0	opt	14.0	mail	34.0	francisco	5.0	apply	20.0
+52	officer	63.0	account setting	23.0	barbara strozzilaan	3.0	visit	20.0	account setting	23.0	barbara strozzilaan	3.0	visit	20.0	account setting	23.0	barbara strozzilaan	3.0	visit	20.0	interest	37	website	35.0	commissioners	5.0	describe	21.0	update	21.0	personal data	2.0	visit	14.0	website	34.0	facebook	5.0	resolve	20.0
+53	law	61.0	object	22.0	tandem	3.0	transfer	19.0	object	22.0	tandem	3.0	transfer	19.0	object	22.0	tandem	3.0	transfer	19.0	datum concern	36	update	34.0	account	5.0	apply	20.0	collection	21.0	-urlor	2.0	transfer	13.0	article	33.0	department	5.0	transfer	19.0
+54	format	60.0	update	22.0	game	3.0	let	19.0	update	22.0	game	3.0	let	19.0	update	22.0	game	3.0	let	19.0	obtain	36	article	33.0	switzerland	5.0	find	20.0	practice	21.0	supervisory authority	2.0	learn	13.0	update	33.0	shield	5.0	let	19.0
+55	like	57.0	comment	22.0	thomson reuters	3.0	note	18.0	comment	22.0	thomson reuters	3.0	note	18.0	comment	22.0	thomson reuters	3.0	note	18.0	way	35	age	33.0	netherlands	5.0	visit	20.0	relation	20.0	privacy settings	2.0	retain	13.0	profile	33.0	ooo	5.0	note	18.0
+56	believe	57.0	order	22.0	-emailor	3.0	edit	16.0	order	22.0	-emailor	3.0	edit	16.0	order	22.0	-emailor	3.0	edit	16.0	section	35	profile	32.0	san	5.0	transfer	19.0	situation	20.0	rooster teeth productions llc	2.0	entitle	12.0	age	33.0	uber	5.0	visit	18.0
+57	marketing	56.0	contact detail	22.0	san francisco	3.0	complain	16.0	contact detail	22.0	san francisco	3.0	complain	16.0	contact detail	22.0	san francisco	3.0	complain	16.0	data portability	33	officer	31.0	reuters	5.0	let	19.0	application	20.0	e 51st st austin tx	2.0	override	12.0	collection	28.0	section	5.0	learn	15.0
+58	mail	56.0	practice	22.0	privacy notice	3.0	learn	15.0	practice	22.0	privacy notice	3.0	learn	15.0	practice	22.0	privacy notice	3.0	learn	15.0	rectification	32	collection	28.0	thomson	5.0	note	18.0	order	19.0	legal department	2.0	prevent	12.0	case	28.0	legal	5.0	override	15.0
+59	article	55.0	situation	21.0	zuuks games	3.0	override	15.0	situation	21.0	zuuks games	3.0	override	15.0	situation	21.0	zuuks games	3.0	override	15.0	restriction	32	case	28.0	francisco	5.0	complain	16.0	privacy practice	19.0	belarus minsk	2.0	verify	11.0	basis	27.0	international	5.0	prevent	14.0
+60	erase	55.0	correction	21.0	tantan	3.0	inform	15.0	correction	21.0	tantan	3.0	inform	15.0	correction	21.0	tantan	3.0	inform	15.0	e-mail	32	basis	27.0	company	5.0	learn	15.0	-url-	18.0	doubleugames	2.0	enable	11.0	game	25.0	platform	5.0	find	14.0
+61	readable	54.0	collection	21.0	medium	3.0	stop	14.0	collection	21.0	medium	3.0	stop	14.0	collection	21.0	medium	3.0	stop	14.0	party	31	game	25.0	department	5.0	override	15.0	data protection authority	18.0	irish data protection commission	2.0	feel	11.0	officer	25.0	europe	5.0	retain	14.0
+62	legitimate	54.0	email address	21.0	supervisory authority	3.0	prevent	14.0	email address	21.0	supervisory authority	3.0	prevent	14.0	email address	21.0	supervisory authority	3.0	prevent	14.0	circumstance	31	correction	25.0	shield	5.0	inform	15.0	correction	18.0	yumobi tekhnolodzhi ooo	2.0	apply	11.0	correction	25.0	service	4.0	inform	13.0
+63	erasure	53.0	relation	20.0	amino	3.0	apply	14.0	relation	20.0	amino	3.0	apply	14.0	relation	20.0	amino	3.0	apply	14.0	age	31	application	24.0	ooo	5.0	prevent	14.0	email address	18.0	yumobi tekhnolodzhi ooo support	2.0	inform	11.0	application	24.0	advertising	4.0	address	13.0
+64	machine	53.0	reason	20.0	nekki limited	3.0	retain	14.0	reason	20.0	nekki limited	3.0	retain	14.0	reason	20.0	nekki limited	3.0	retain	14.0	share	30	object	23.0	section	5.0	retain	14.0	data protection officer	18.0	privacy policy administrator	2.0	accord	10.0	object	23.0	paris	4.0	view	13.0
+65	inaccurate	53.0	application	20.0	privacy statement	3.0	set	13.0	application	20.0	privacy statement	3.0	set	13.0	application	20.0	privacy statement	3.0	set	13.0	write	30	e	23.0	international	5.0	accord	13.0	data controller	18.0	section	2.0	set	10.0	order	23.0	ny	4.0	demand	12.0
+66	portability	51.0	parent	19.0	support center	3.0	address	13.0	data protection authority	19.0	support center	3.0	address	13.0	parent	19.0	support center	3.0	address	13.0	privacy	29	order	22.0	platform	5.0	set	13.0	contact detail	18.0	bdsg	2.0	choose	10.0	situation	21.0	administrator	4.0	entitle	12.0
+67	child	51.0	contact information	19.0	periscope	3.0	demand	12.0	parent	19.0	periscope	3.0	demand	12.0	contact information	19.0	periscope	3.0	accord	12.0	modify	28	situation	21.0	homa	5.0	address	13.0	addition	17.0	faubourg saint	2.0	find	10.0	change	21.0	usa	4.0	set	12.0
+68	applicable	50.0	data controller	19.0	twitter international company	3.0	accord	12.0	contact information	19.0	twitter international company	3.0	accord	12.0	data controller	19.0	twitter international company	3.0	demand	12.0	controller	28	change	21.0	service	4.0	view	13.0	claim	17.0	homa	2.0	associate	10.0	form	21.0	statement	4.0	enable	12.0
+69	restriction	50.0	privacy practice	19.0	headspace	3.0	entitle	12.0	data controller	19.0	headspace	3.0	entitle	12.0	privacy practice	19.0	headspace	3.0	entitle	12.0	rectify	27	form	21.0	advertising	4.0	demand	12.0	detail	17.0	sega europe limited customer services	2.0	consider	10.0	relation	20.0	notice	4.0	amend	12.0
+70	practice	50.0	-url-	18.0	homa	3.0	enable	12.0	privacy practice	19.0	homa	3.0	enable	12.0	-url-	18.0	homa	3.0	enable	12.0	basis	27	relation	20.0	paris	4.0	entitle	12.0	reason	17.0	great west road brentford middlesex tw8	2.0	disclose	10.0	reason	20.0	webmartgroup	4.0	associate	12.0
+71	obtain	49.0	data protection authority	18.0	platform	3.0	associate	12.0	-url-	18.0	platform	3.0	associate	12.0	data protection authority	18.0	platform	3.0	associate	12.0	transmit	27	reason	20.0	ny	4.0	enable	12.0	parent	17.0	mortimer street london w1 t	2.0	explain	10.0	-url-	19.0	account	4.0	accord	11.0
+72	include	49.0	change	18.0	contact	3.0	carry	11.0	change	18.0	contact	3.0	carry	11.0	change	18.0	contact	3.0	carry	11.0	request access	27	-url-	19.0	administrator	4.0	amend	12.0	comment	17.0	data privacy management grci law limited	2.0	give	9.0	subject	19.0	company	4.0	carry	11.0
+73	support	49.0	data protection officer	18.0	playdemic	3.0	verify	11.0	data protection officer	18.0	playdemic	3.0	verify	11.0	data protection officer	18.0	playdemic	3.0	verify	11.0	app	27	subject	19.0	game	4.0	associate	12.0	question comment	17.0	boyne tower bull ring lagavooren drogheda co	2.0	permit	9.0	obligation	19.0	doubleugames	4.0	verify	11.0
+74	direct	46.0	addition	17.0	tgtg	3.0	permit	11.0	addition	17.0	tgtg	3.0	permit	11.0	addition	17.0	tgtg	3.0	permit	11.0	withdraw	26	obligation	19.0	usa	4.0	carry	11.0	message	16.0	governance europe	2.0	allege	9.0	device	19.0	tekhnolodzhi	4.0	reach	11.0
+75	remove	46.0	claim	17.0	privacy center	3.0	consider	11.0	claim	17.0	privacy center	3.0	consider	11.0	claim	17.0	privacy center	3.0	consider	11.0	submit	26	device	19.0	statement	4.0	verify	11.0	accuracy	15.0	head	2.0	agree	9.0	parent	19.0	yumobi	4.0	consider	11.0
+76	accordance	45.0	content	17.0	singapore	2.0	choose	11.0	content	17.0	singapore	2.0	choose	11.0	content	17.0	singapore	2.0	choose	11.0	website	26	parent	19.0	notice	4.0	permit	11.0	content	15.0	spotify	2.0	carry	9.0	addition	18.0	lane	4.0	choose	11.0
+77	follow	45.0	suggestion	17.0	livu	2.0	control	11.0	suggestion	17.0	livu	2.0	control	11.0	suggestion	17.0	livu	2.0	control	11.0	limit	25	addition	18.0	webmartgroup	4.0	consider	11.0	change	15.0	spotify usa inc	2.0	view	9.0	accuracy	17.0	homa	4.0	complete	11.0
+78	url	45.0	marketing	17.0	customer	2.0	locate	11.0	marketing	17.0	customer	2.0	locate	11.0	marketing	17.0	customer	2.0	locate	11.0	question regard	25	content	18.0	icbc	4.0	choose	11.0	obligation	15.0	privacy office	2.0	demand	8.0	claim	17.0	contact	4.0	locate	11.0
+79	rectify	44.0	question comment	17.0	google analytics	2.0	register	11.0	question comment	17.0	google analytics	2.0	register	11.0	question comment	17.0	google analytics	2.0	register	11.0	marketing purpose	25	accuracy	17.0	tekhnolodzhi	4.0	control	11.0	game	15.0	suntec tower	1.0	automate	8.0	content	17.0	spotify	4.0	disclose	11.0
+80	base	44.0	delay	16.0	advertising demand partner	2.0	disclose	11.0	delay	16.0	advertising demand partner	2.0	disclose	11.0	delay	16.0	advertising demand partner	2.0	disclose	11.0	know	25	claim	17.0	yumobi	4.0	complete	11.0	marketing	15.0	temasek	1.0	comply	8.0	suggestion	17.0	email	3.0	explain	11.0
+81	comment	43.0	accuracy	16.0	publisher partner	2.0	explain	11.0	accuracy	16.0	publisher partner	2.0	explain	11.0	accuracy	16.0	publisher partner	2.0	explain	11.0	store	24	suggestion	17.0	dingtone	4.0	locate	11.0	delay	14.0	para	1.0	infringe	8.0	delay	16.0	tower	3.0	add	10.0
+82	circumstance	42.0	message	16.0	paris france	2.0	give	10.0	message	16.0	paris france	2.0	give	10.0	message	16.0	paris france	2.0	give	10.0	data protection authority	24	cookie	17.0	apple	4.0	register	11.0	object	14.0	lingodeer	1.0	register	8.0	issue	16.0	analytics	3.0	give	10.0
+83	rectification	41.0	profiling	16.0	hn amsterdam	2.0	comply	10.0	profiling	16.0	hn amsterdam	2.0	comply	10.0	page	15.0	hn amsterdam	2.0	comply	10.0	log	23	delay	16.0	lane	4.0	disclose	11.0	device	14.0	designated countriemay	1.0	post	8.0	cookie	16.0	co	3.0	continue	10.0
+84	subject	41.0	page	15.0	support service	2.0	refer	10.0	page	15.0	support service	2.0	refer	10.0	obligation	15.0	support service	2.0	refer	10.0	account setting	23	issue	16.0	contact	4.0	explain	11.0	page	14.0	freedom circle	1.0	respond	8.0	message	16.0	france	3.0	comply	10.0
+85	structured	40.0	obligation	15.0	w 44th street new york ny	2.0	respond	10.0	obligation	15.0	w 44th street new york ny	2.0	respond	10.0	game	15.0	w 44th street new york ny	2.0	respond	10.0	setting	23	query	16.0	tgtg	4.0	add	10.0	art	13.0	santa clara	1.0	allow	8.0	contract	15.0	amsterdam	3.0	manage	10.0
+86	deletion	40.0	game	15.0	interactive	2.0	view	10.0	game	15.0	interactive	2.0	view	10.0	profiling	15.0	interactive	2.0	view	10.0	include	23	message	16.0	spotify	4.0	give	10.0	instruction	13.0	metro	1.0	state	7.0	customer	15.0	strozzilaan	3.0	permit	10.0
+87	relate	39.0	art	14.0	profile	2.0	allege	9.0	art	14.0	profile	2.0	allege	9.0	art	14.0	profile	2.0	allege	9.0	data	22	contract	15.0	email	3.0	continue	10.0	portability	13.0	metros privacy officer	1.0	notify	7.0	instruction	15.0	barbara	3.0	control	10.0
+88	review	39.0	query	14.0	usa	2.0	file	9.0	query	14.0	usa	2.0	file	9.0	query	14.0	usa	2.0	file	9.0	ground	22	customer	15.0	tower	3.0	comply	10.0	respect	13.0	metro customer service	1.0	continue	7.0	company	15.0	commission	3.0	register	10.0
+89	long	39.0	device	14.0	uk limited	2.0	manage	9.0	device	14.0	uk limited	2.0	manage	9.0	device	14.0	uk limited	2.0	manage	9.0	practice	22	instruction	15.0	jaumo	3.0	manage	10.0	country	13.0	privacy officer	1.0	amend	7.0	security	15.0	york	3.0	respond	10.0
+90	modify	38.0	resident	14.0	professional	2.0	agree	9.0	resident	14.0	professional	2.0	agree	9.0	resident	14.0	professional	2.0	agree	9.0	detail	21	company	15.0	id	3.0	live	10.0	contact information	13.0	mopub partners	1.0	control	7.0	profiling	15.0	new	3.0	automate	9.0
+91	app	36.0	cookie	14.0	south colonnade	2.0	allow	9.0	cookie	14.0	south colonnade	2.0	allow	9.0	cookie	14.0	south colonnade	2.0	allow	9.0	personal datum	21	system	15.0	lingodeer	3.0	refer	10.0	cookie	13.0	twitters data protection officer	1.0	manage	7.0	art	14.0	w	3.0	allege	9.0
+92	party	35.0	instruction	13.0	mobile war	2.0	state	8.0	instruction	13.0	mobile war	2.0	state	8.0	instruction	13.0	mobile war	2.0	state	8.0	need	21	security	15.0	u.s.-based	3.0	respond	10.0	profiling	13.0	carly solutions gmbh co kg	1.0	contain	7.0	term	14.0	interactive	3.0	agree	9.0
+93	way	35.0	portability	13.0	alexadra games	2.0	disable	8.0	portability	13.0	alexadra games	2.0	disable	8.0	portability	13.0	alexadra games	2.0	disable	8.0	collection	21	profiling	15.0	analytics	3.0	automate	9.0	person	12.0	digital advertising alliances	1.0	supplement	7.0	query	14.0	suite	3.0	allow	9.0
+94	page	35.0	system	13.0	overmobile	2.0	automate	8.0	system	13.0	overmobile	2.0	automate	8.0	system	13.0	overmobile	2.0	automate	8.0	review	20	art	14.0	co	3.0	allege	9.0	charge	12.0	des petites ecuries c	1.0	process base	7.0	country	14.0	south	3.0	state	8.0
+95	withdraw	35.0	term	13.0	minimum	2.0	notify	8.0	term	13.0	minimum	2.0	notify	8.0	term	13.0	minimum	2.0	notify	8.0	feel	20	term	14.0	france	3.0	file	9.0	infringement	12.0	supervisory authority autoriteit persoonsgegevens	1.0	contest	7.0	number	14.0	mobile	3.0	disable	8.0
+96	website	35.0	respect	13.0	-emailand	2.0	oppose	8.0	respect	13.0	-emailand	2.0	oppose	8.0	respect	13.0	-emailand	2.0	oppose	8.0	situation	20	country	14.0	barbara	3.0	agree	9.0	mean	12.0	personal data protection commission	1.0	address	7.0	activity	14.0	zuuks	3.0	erasure	8.0
+97	ground	34.0	country	13.0	trustarc	2.0	erasure	8.0	country	13.0	trustarc	2.0	erasure	8.0	country	13.0	trustarc	2.0	erasure	8.0	case	20	resident	14.0	strozzilaan	3.0	allow	9.0	resident	12.0	internet privacy policy	1.0	make	6.0	communication	14.0	cyprus	3.0	make	8.0
+98	profile	34.0	inaccuracy	12.0	customer support	2.0	make	8.0	inaccuracy	12.0	customer support	2.0	make	8.0	inaccuracy	12.0	customer support	2.0	make	8.0	reach	20	number	14.0	amsterdam	3.0	state	8.0	example	12.0	internet privacy policy administrator	1.0	export	6.0	business	14.0	icbc	3.0	work	8.0
+99	store	33.0	person	12.0	icbc	2.0	amend	8.0	person	12.0	icbc	2.0	amend	8.0	person	12.0	icbc	2.0	amend	8.0	data controller	20	business	14.0	commission	3.0	disable	8.0	inaccuracy	11.0	eprivacy gmbh	1.0	reach	6.0	browser	13.0	code	3.0	infringe	8.0
+100	commonly	33.0	objection	12.0	homer	2.0	forget	8.0	objection	12.0	homer	2.0	forget	8.0	objection	12.0	homer	2.0	forget	8.0	transfer	19	browser	13.0	interactive	3.0	notify	8.0	term	11.0	prof	1.0	complete	6.0	system	13.0	nekki	3.0	post	8.0
+101	directly	33.0	account information	12.0	-urlor	2.0	infringe	8.0	account information	12.0	-urlor	2.0	infringe	8.0	account information	12.0	-urlor	2.0	infringe	8.0	art	19	respect	13.0	w	3.0	oppose	8.0	objection	11.0	tap4fun co. ltd	1.0	access modify	6.0	respect	13.0	law	3.0	supplement	8.0
+102	age	33.0	infringement	12.0	musescore	2.0	complete	8.0	charge	12.0	musescore	2.0	complete	8.0	charge	12.0	musescore	2.0	complete	8.0	relation	19	objection	13.0	new	3.0	erasure	8.0	form	11.0	privacy administrator	1.0	identify	6.0	objection	13.0	st	3.0	notify	7.0
+103	incomplete	32.0	mean	12.0	privacy settings	2.0	live	8.0	infringement	12.0	privacy settings	2.0	live	8.0	infringement	12.0	privacy settings	2.0	live	8.0	application	19	link	13.0	york	3.0	make	8.0	account information	11.0	chengdu sichuan china	1.0	locate	6.0	resident	13.0	centre	3.0	oppose	7.0
+104	share	32.0	example	12.0	e 51st st austin tx	2.0	post	8.0	example	12.0	rooster teeth productions llc	2.0	post	8.0	mean	12.0	rooster teeth productions llc	2.0	post	8.0	deletion	19	provider	13.0	tandem	3.0	forget	8.0	data protection	10.0	tianfu	1.0	specify	6.0	link	13.0	itv	3.0	undergo	7.0
+105	write	32.0	form	11.0	rooster teeth productions llc	2.0	supplement	8.0	e	11.0	e 51st st austin tx	2.0	supplement	8.0	example	12.0	e 51st st austin tx	2.0	supplement	8.0	comment	19	activity	13.0	suite	3.0	infringe	8.0	guardian	10.0	tile inc.	1.0	edit	6.0	provider	13.0	w1	3.0	export	7.0
+106	relevant	31.0	charge	11.0	legal department	2.0	direct	8.0	form	11.0	legal department	2.0	direct	8.0	form	11.0	legal department	2.0	direct	8.0	follow	19	example	13.0	south	3.0	work	8.0	data subject	10.0	s el camino real suite	1.0	disable	6.0	example	13.0	house	3.0	reside	7.0
+107	require	31.0	issue	11.0	saygames	2.0	undergo	7.0	mean	11.0	saygames	2.0	undergo	7.0	issue	11.0	saygames	2.0	undergo	7.0	order	19	communication	13.0	-emailor	3.0	post	8.0	link	10.0	san mateo	1.0	refer	6.0	exercise	13.0	road	3.0	live	7.0
+108	free	31.0	data protection	10.0	belarus minsk	2.0	continue	7.0	issue	11.0	belarus minsk	2.0	continue	7.0	data protection	10.0	belarus minsk	2.0	continue	7.0	marketing	19	exercise	13.0	mobile	3.0	supplement	8.0	inquiry	10.0	privacy team thomson reuters	1.0	download	6.0	person	12.0	sega	3.0	mail	7.0
+109	game	29.0	condition	10.0	topface	2.0	export	7.0	data protection	10.0	topface	2.0	export	7.0	condition	10.0	topface	2.0	export	7.0	concern regard	19	inaccuracy	12.0	technologies	3.0	direct	8.0	condition	9.0	canary wharf london	1.0	click	6.0	registration	12.0	singapore	2.0	offer	7.0
+110	necessary	29.0	company	10.0	direct	2.0	mail	7.0	condition	10.0	direct	2.0	mail	7.0	company	10.0	direct	2.0	mail	7.0	correction	18	person	12.0	zuuks	3.0	undergo	7.0	company	9.0	statement	1.0	consent	6.0	charge	12.0	art	2.0	contain	7.0
+111	edit	28.0	guardian	10.0	irish data protection commission	2.0	offer	7.0	company	10.0	irish data protection commission	2.0	offer	7.0	guardian	10.0	irish data protection commission	2.0	offer	7.0	parent	18	registration	12.0	cyprus	3.0	export	7.0	system	9.0	data protection officer thomson reuters	1.0	list	6.0	infringement	12.0	metro	2.0	contest	7.0
+112	limit	28.0	choice	10.0	principles	2.0	contain	7.0	guardian	10.0	principles	2.0	contain	7.0	choice	10.0	principles	2.0	contain	7.0	visit	18	charge	12.0	tantan	3.0	reside	7.0	freedom	9.0	canary wharf london e14	1.0	meet	5.0	preference	12.0	mopub	2.0	file	7.0
+113	collection	28.0	data subject	10.0	yumobi tekhnolodzhi ooo	2.0	process base	7.0	choice	10.0	yumobi tekhnolodzhi ooo	2.0	process base	7.0	data subject	10.0	yumobi tekhnolodzhi ooo	2.0	process base	7.0	respect	17	infringement	12.0	medium	3.0	mail	7.0	query	9.0	twitch services	1.0	check	5.0	mean	12.0	partner	2.0	download	7.0
+114	submit	28.0	link	10.0	yumobi tekhnolodzhi ooo support	2.0	contest	7.0	data subject	10.0	yumobi tekhnolodzhi ooo support	2.0	contest	7.0	link	10.0	yumobi tekhnolodzhi ooo support	2.0	contest	7.0	note	17	preference	12.0	code	3.0	offer	7.0	datum protection	9.0	twitch interactive inc.	1.0	rely	5.0	inquiry	12.0	demand	2.0	list	7.0
+115	transmit	27.0	inquiry	10.0	camel games	2.0	download	7.0	link	10.0	camel games	2.0	download	7.0	inquiry	10.0	camel games	2.0	download	7.0	resolve	17	mean	12.0	amino	3.0	contain	7.0	suggestion	9.0	bush street	1.0	enter	5.0	inaccuracy	11.0	publisher	2.0	refer	7.0
+116	customer	26.0	freedom	9.0	flaregames	2.0	list	7.0	inquiry	10.0	flaregames	2.0	list	7.0	freedom	9.0	flaregames	2.0	list	7.0	let	17	inquiry	12.0	nekki	3.0	contest	7.0	mail address	9.0	vertigo games sepapaja	1.0	follow apply	5.0	disclosure	11.0	efta	2.0	protect	7.0
+117	basis	26.0	profile	9.0	privacy policy administrator	2.0	protect	7.0	freedom	9.0	privacy policy administrator	2.0	protect	7.0	profile	9.0	privacy policy administrator	2.0	protect	7.0	question comment	17	disclosure	11.0	law	3.0	download	7.0	choice	9.0	tallinn	1.0	seek	5.0	member	11.0	gmbh	2.0	affect	7.0
+118	know	26.0	datum protection	9.0	section	2.0	affect	7.0	profile	9.0	section	2.0	affect	7.0	e	9.0	section	2.0	affect	7.0	delay	16	site	11.0	st	3.0	list	7.0	issue	9.0	estonia	1.0	grant	5.0	advertising	11.0	digital	2.0	handle	6.0
+119	particular	26.0	site	9.0	bdsg	2.0	cease	7.0	datum protection	9.0	bdsg	2.0	cease	7.0	datum protection	9.0	bdsg	2.0	cease	7.0	require	16	member	11.0	saygames	3.0	protect	7.0	security	9.0	netherlands data authority	1.0	ensure	5.0	condition	10.0	hn	2.0	enter	6.0
+120	case	26.0	officer	9.0	google account	2.0	add	6.0	site	9.0	google account	2.0	add	6.0	site	9.0	google account	2.0	add	6.0	addition	16	advertising	11.0	periscope	3.0	affect	7.0	establishment exercise	9.0	mobile war	1.0	take	5.0	tool	10.0	persoonsgegevens	2.0	think	6.0
+121	correction	25.0	mail address	9.0	itv	2.0	handle	6.0	officer	9.0	itv	2.0	handle	6.0	officer	9.0	itv	2.0	handle	6.0	accuracy	16	condition	10.0	centre	3.0	cease	7.0	defense	9.0	information	1.0	unsubscribe	5.0	guardian	10.0	autoriteit	2.0	hesitate	6.0
+122	form	25.0	floor	9.0	faubourg saint	2.0	think	6.0	mail address	9.0	faubourg saint	2.0	think	6.0	mail address	9.0	faubourg saint	2.0	think	6.0	reason	16	tool	10.0	headspace	3.0	handle	6.0	compliance	9.0	data request portal	1.0	access edit	5.0	site	10.0	social	2.0	seek	6.0
+123	opt	25.0	security	9.0	homa games	2.0	hesitate	6.0	floor	9.0	homa games	2.0	hesitate	6.0	floor	9.0	homa games	2.0	hesitate	6.0	complain	16	guardian	10.0	itv	3.0	enter	6.0	contract	8.0	personal data request portal	1.0	occur	5.0	dispute	10.0	44th	2.0	identify	6.0
+124	state	24.0	establishment exercise	9.0	fireproof	2.0	access modify	6.0	security	9.0	fireproof	2.0	access modify	6.0	security	9.0	fireproof	2.0	access modify	6.0	personal data	16	dispute	10.0	w1	3.0	think	6.0	data processing	8.0	zynga inc.	1.0	close	5.0	choice	10.0	internet	2.0	specify	6.0
+125	log	24.0	defense	9.0	great west road brentford middlesex tw8	2.0	seek	6.0	establishment exercise	9.0	great west road brentford middlesex tw8	2.0	seek	6.0	establishment exercise	9.0	sega europe limited customer services	2.0	seek	6.0	find	16	choice	10.0	house	3.0	hesitate	6.0	disclosure	8.0	customer support page	1.0	go	5.0	performance	10.0	profile	2.0	forget	6.0
+126	application	24.0	compliance	9.0	sega europe limited customer services	2.0	identify	6.0	defense	9.0	sega europe limited customer services	2.0	identify	6.0	defense	9.0	great west road brentford middlesex tw8	2.0	identify	6.0	personal information	16	performance	10.0	fireproof	3.0	seek	6.0	profile	8.0	street san francisco	1.0	try	5.0	matter	10.0	professional	2.0	complain	6.0
+127	european	24.0	provision	9.0	mcdonald	2.0	specify	6.0	compliance	9.0	mcdonald	2.0	specify	6.0	compliance	9.0	mcdonald	2.0	specify	6.0	demand	15	matter	10.0	sega	3.0	identify	6.0	product	8.0	authority	1.0	affect	5.0	notice	10.0	wharf	2.0	report	6.0
+128	eu	24.0	contract	8.0	mortimer street london w1 t	2.0	report	6.0	provision	9.0	mortimer street london w1 t	2.0	report	6.0	provision	9.0	mortimer street london w1 t	2.0	report	6.0	email address	15	notice	10.0	road	3.0	specify	6.0	attn	8.0	protection	1.0	maintain	5.0	list	9.0	canary	2.0	mention	6.0
+129	incorrect	23.0	data processing	8.0	boyne tower bull ring lagavooren drogheda co	2.0	mention	6.0	contract	8.0	data privacy management grci law limited	2.0	mention	6.0	contract	8.0	data privacy management grci law limited	2.0	mention	6.0	contact information	15	list	9.0	playdemic	3.0	report	6.0	violation	8.0	personal information protection act	1.0	add	4.0	freedom	9.0	team	2.0	close	6.0
+130	transfer	23.0	disclosure	8.0	data privacy management grci law limited	2.0	refuse	6.0	data processing	8.0	boyne tower bull ring lagavooren drogheda co	2.0	refuse	6.0	data processing	8.0	boyne tower bull ring lagavooren drogheda co	2.0	refuse	6.0	game	15	f	9.0	singapore	2.0	mention	6.0	provision	8.0	gdask poland	1.0	establish	4.0	option	9.0	colonnade	2.0	click	6.0
+131	emailor	23.0	recipient	8.0	governance europe	2.0	close	6.0	disclosure	8.0	governance europe	2.0	close	6.0	disclosure	8.0	governance europe	2.0	close	6.0	data protection	14	freedom	9.0	livu	2.0	refuse	6.0	processing activity	8.0	zacna	1.0	oppose	4.0	recipient	9.0	-emailor	2.0	try	6.0
+132	feel	22.0	e	8.0	head	2.0	click	6.0	recipient	8.0	head	2.0	click	6.0	recipient	8.0	head	2.0	click	6.0	learn	14	option	9.0	metro	2.0	close	6.0	recipient	7.0	street	1.0	erasure	4.0	place	9.0	bush	2.0	consent	6.0
+133	need	22.0	product	8.0	spotify	2.0	try	6.0	product	8.0	spotify	2.0	try	6.0	product	8.0	spotify	2.0	try	6.0	restrict processing	14	recipient	9.0	mopub	2.0	click	6.0	site	7.0	carx technologies limited	1.0	enforce	4.0	violation	9.0	war	2.0	meet	5.0
+134	13	22.0	writing	8.0	spotify usa inc	2.0	consent	6.0	writing	8.0	spotify usa inc	2.0	consent	6.0	writing	8.0	spotify usa inc	2.0	consent	6.0	content	14	place	9.0	partner	2.0	try	6.0	member	7.0	user experience improvement program location access	1.0	delete object	4.0	defense	9.0	portal	2.0	appoint	5.0
+135	reach	22.0	attn	8.0	privacy office	2.0	meet	5.0	violation	8.0	privacy office	2.0	meet	5.0	attn	8.0	privacy office	2.0	meet	5.0	obligation	14	floor	9.0	publisher	2.0	consent	6.0	floor	7.0	mi account	1.0	decline	4.0	establishment	9.0	request	2.0	check	5.0
+136	identifiable	22.0	violation	8.0	netflix	2.0	appoint	5.0	processing activity	8.0	netflix	2.0	appoint	5.0	violation	8.0	netflix	2.0	appoint	5.0	privacy practice	14	violation	9.0	demand	2.0	meet	5.0	browser	7.0	email	1.0	work	4.0	compliance	9.0	act	2.0	rely	5.0
+137	general	21.0	processing activity	8.0	suntec tower	1.0	check	5.0	datum controller	7.0	suntec tower	1.0	check	5.0	processing activity	8.0	suntec tower	1.0	check	5.0	edit	13	establishment	9.0	efta	2.0	appoint	5.0	writing	7.0	european economic area canada costa rica	1.0	sign	4.0	provision	9.0	alexadra	2.0	arise	5.0
+138	resolve	21.0	datum controller	7.0	temasek	1.0	rely	5.0	decision	7.0	temasek	1.0	rely	5.0	removal	7.0	temasek	1.0	rely	5.0	system	13	defense	9.0	gmbh	2.0	check	5.0	event	7.0	lockhart ro wan chai h.k	1.0	mean	4.0	decision	8.0	technologies	2.0	mean	5.0
+139	following	21.0	decision	7.0	jagex limited	1.0	enter	5.0	option	7.0	jagex limited	1.0	enter	5.0	datum controller	7.0	jagex limited	1.0	enter	5.0	claim	13	compliance	9.0	digital	2.0	rely	5.0	jurisdiction	7.0	rm	1.0	handle	4.0	feature	8.0	user	2.0	decide	5.0
+140	stop	20.0	option	7.0	para	1.0	reside	5.0	member	7.0	para	1.0	reside	5.0	option	7.0	para	1.0	reside	5.0	device	13	provision	9.0	hn	2.0	arise	5.0	notice	7.0	lockhart	1.0	decide	4.0	team	8.0	avenue	2.0	grant	5.0
+141	additional	20.0	member	7.0	jaumos	1.0	follow apply	5.0	browser	7.0	jaumos	1.0	follow apply	5.0	member	7.0	jaumos	1.0	follow apply	5.0	form	13	decision	8.0	persoonsgegevens	2.0	mean	5.0	ability	7.0	dvapps ab	1.0	live	4.0	product	8.0	nicosia	2.0	ensure	5.0
+142	art	20.0	browser	7.0	id	1.0	arise	5.0	date	7.0	id	1.0	arise	5.0	browser	7.0	id	1.0	arise	5.0	mean	13	feature	8.0	autoriteit	2.0	decide	5.0	tool	6.0	dvloper	1.0	respect	4.0	date	8.0	microsoft	2.0	help	5.0
+143	situation	20.0	date	7.0	account	1.0	mean	5.0	enquiry	7.0	account	1.0	mean	5.0	date	7.0	account	1.0	mean	5.0	ground relate	13	team	8.0	social	2.0	grant	5.0	prejudice	6.0	easybrain ltd	1.0	help	4.0	writing	8.0	representative	2.0	take	5.0
+144	local	19.0	enquiry	7.0	apps	1.0	decide	5.0	attn	7.0	apps	1.0	decide	5.0	enquiry	7.0	apps	1.0	decide	5.0	delete information	13	product	8.0	internet	2.0	e	5.0	file	6.0	krinou street	1.0	stop process	4.0	help	8.0	business	2.0	unsubscribe	5.0
+145	obligation	19.0	event	7.0	designated countriemay	1.0	grant	5.0	event	7.0	designated countriemay	1.0	grant	5.0	event	7.0	designated countriemay	1.0	grant	5.0	file	12	writing	8.0	44th	2.0	ensure	5.0	data protection law	6.0	limassol cyprus	1.0	adjust	4.0	year	8.0	-urlor	2.0	conduct	5.0
+146	apply	19.0	jurisdiction	7.0	freedom circle	1.0	ensure	5.0	jurisdiction	7.0	santa clara	1.0	ensure	5.0	jurisdiction	7.0	santa clara	1.0	ensure	5.0	term	12	help	8.0	profile	2.0	help	5.0	removal	6.0	oval	1.0	head	4.0	file	7.0	game	2.0	confirm	5.0
+147	device	19.0	matter	7.0	santa clara	1.0	indicate	5.0	matter	7.0	freedom circle	1.0	indicate	5.0	matter	7.0	freedom circle	1.0	indicate	5.0	query	12	year	8.0	professional	2.0	take	5.0	type	6.0	stakhanovskaya	1.0	mail	4.0	owner	7.0	lion	2.0	occur	5.0
+148	parent	19.0	notice	7.0	privacy laws	1.0	take	5.0	notice	7.0	privacy laws	1.0	take	5.0	notice	7.0	privacy laws	1.0	take	5.0	post	12	attn	8.0	team	2.0	unsubscribe	5.0	datum controller	6.0	technopark perm	1.0	confirm	4.0	period	7.0	studios	2.0	refuse	5.0
+149	let	19.0	ability	7.0	metros privacy officer	1.0	unsubscribe	5.0	ability	7.0	metros privacy officer	1.0	unsubscribe	5.0	ability	7.0	metro	1.0	unsubscribe	5.0	charge	12	file	7.0	colonnade	2.0	welcome	5.0	decision	6.0	strovolos avenue petousis	1.0	conduct	4.0	e	7.0	medium	2.0	desire	5.0
+150	entitled	18.0	record	7.0	metro customer service	1.0	welcome	5.0	record	7.0	metro customer service	1.0	welcome	5.0	record	7.0	metros privacy officer	1.0	welcome	5.0	suggestion	12	removal	7.0	canary	2.0	conduct	5.0	option	6.0	strovolos nicosia cyprus	1.0	arise	4.0	floor	7.0	civil	2.0	display	5.0
+151	demand	18.0	tool	6.0	privacy officer	1.0	access edit	5.0	tool	6.0	privacy officer	1.0	access edit	5.0	tool	6.0	metro customer service	1.0	access edit	5.0	opt	12	owner	7.0	wharf	2.0	confirm	5.0	instance	6.0	personal data protection	1.0	mention	4.0	phone	7.0	settings	2.0	go	5.0
+152	office	18.0	prejudice	6.0	mobisystems inc	1.0	conduct	5.0	f	6.0	mobisystems inc	1.0	conduct	5.0	prejudice	6.0	privacy officer	1.0	conduct	5.0	describe	12	period	7.0	bush	2.0	occur	5.0	work	6.0	commissioner	1.0	reside	4.0	control	7.0	tx	2.0	maintain	5.0
+153	member	18.0	file	6.0	flurry analytics	1.0	confirm	5.0	prejudice	6.0	flurry analytics	1.0	confirm	5.0	file	6.0	mobisystems inc	1.0	confirm	5.0	general data protection regulation	11	phone	7.0	war	2.0	desire	5.0	profile information	6.0	genera games s.l cardenal bueno monreal	1.0	refuse	4.0	storage	7.0	austin	2.0	deactivate	5.0
+154	note	18.0	data protection law	6.0	mopubs	1.0	occur	5.0	file	6.0	mopubs	1.0	occur	5.0	data protection law	6.0	flurry analytics	1.0	occur	5.0	enable	11	control	7.0	portal	2.0	display	5.0	control	6.0	sevilla spain	1.0	access rectify	4.0	confirmation	7.0	51st	2.0	cease	5.0
+155	content	18.0	removal	6.0	mopub partners	1.0	desire	5.0	data protection law	6.0	mopub partners	1.0	desire	5.0	type	6.0	mopubs	1.0	desire	5.0	person	11	storage	7.0	request	2.0	go	5.0	year	6.0	planta	1.0	desire	4.0	attn	7.0	e	2.0	establish	4.0
+156	visit	18.0	type	6.0	twitters data protection officer	1.0	display	5.0	removal	6.0	twitters data protection officer	1.0	display	5.0	decision	6.0	mopub partners	1.0	display	5.0	inform	11	date	7.0	act	2.0	maintain	5.0	enquiry	6.0	microsoft chief privacy officer	1.0	display	4.0	event	7.0	productions	2.0	enforce	4.0
+157	16	17.0	post	6.0	carly solutions gmbh co kg	1.0	go	5.0	type	6.0	carly solutions gmbh co kg	1.0	go	5.0	post	6.0	twitters data protection officer	1.0	go	5.0	datum protection	11	enquiry	7.0	alexadra	2.0	deactivate	5.0	extent	6.0	eu data protection officer	1.0	deactivate	4.0	jurisdiction	7.0	teeth	2.0	assert	4.0
+158	responsible	17.0	support team	6.0	paypal	1.0	maintain	5.0	post	6.0	paypal	1.0	maintain	5.0	support team	6.0	carly solutions gmbh co kg	1.0	maintain	5.0	country	11	confirmation	7.0	overmobile	2.0	establish	4.0	step	6.0	netmarble	1.0	create	4.0	balancing	7.0	rooster	2.0	decline	4.0
+159	available	17.0	instance	6.0	digital advertising alliances	1.0	deactivate	5.0	support team	6.0	digital advertising alliances	1.0	deactivate	5.0	instance	6.0	paypal	1.0	deactivate	5.0	consider	11	event	7.0	app	2.0	enforce	4.0	customer	6.0	privacy protection department	1.0	load	3.0	ability	7.0	id	2.0	sign	4.0
+160	company	17.0	work	6.0	europe	1.0	establish	4.0	instance	6.0	europe	1.0	establish	4.0	work	6.0	digital advertising alliances	1.0	establish	4.0	account information	11	jurisdiction	7.0	user	2.0	assert	4.0	description	6.0	eu local representative	1.0	undergo	3.0	regulator	7.0	minsk	2.0	respect	4.0
+161	accuracy	17.0	profile information	6.0	des petites ecuries c	1.0	enforce	4.0	work	6.0	des petites ecuries c	1.0	enforce	4.0	profile information	6.0	europe	1.0	enforce	4.0	control	11	balancing	7.0	minimum	2.0	decline	4.0	business	6.0	icbc mobile banking	1.0	cancel	3.0	paragraph	6.0	belarus	2.0	call	4.0
+162	claim	17.0	control	6.0	flow	1.0	delete object	4.0	profile information	6.0	flow	1.0	delete object	4.0	control	6.0	des petites ecuries c	1.0	delete object	4.0	retain	11	ability	7.0	nicosia	2.0	sign	4.0	matter	6.0	user information policy	1.0	correct update	3.0	letter	6.0	rights	2.0	investigate	4.0
+163	limited	17.0	method	6.0	r2games	1.0	decline	4.0	control	6.0	r2games	1.0	decline	4.0	method	6.0	flow	1.0	decline	4.0	european economic area	11	record	7.0	avenue	2.0	revoke	4.0	paragraph	5.0	bank	1.0	charge	3.0	f	6.0	irish	2.0	adjust	4.0
+164	issue	17.0	year	6.0	rules	1.0	work	4.0	method	6.0	rules	1.0	work	4.0	year	6.0	r2games	1.0	work	4.0	contact detail	11	regulator	7.0	-emailand	2.0	de	4.0	f	5.0	icbc	1.0	process pende	3.0	prejudice	6.0	camel	2.0	block	4.0
+165	reason	17.0	place	6.0	relive	1.0	sign	4.0	year	6.0	relive	1.0	sign	4.0	place	6.0	rules	1.0	sign	4.0	-emailor	11	paragraph	6.0	microsoft	2.0	respect	4.0	alternative	5.0	thinking ape entertainment ltd	1.0	situate	3.0	removal	6.0	market	2.0	head	4.0
+166	immediately	17.0	communication	6.0	supervisory authority autoriteit persoonsgegevens	1.0	revoke	4.0	place	6.0	supervisory authority autoriteit persoonsgegevens	1.0	revoke	4.0	communication	6.0	relive	1.0	revoke	4.0	message	11	letter	6.0	trustarc	2.0	call	4.0	profile page	5.0	ny ny	1.0	accept	3.0	type	6.0	rue	2.0	raise	4.0
+167	respect	17.0	extent	6.0	skg	1.0	respect	4.0	communication	6.0	skg	1.0	respect	4.0	extent	6.0	supervisory authority autoriteit persoonsgegevens	1.0	respect	4.0	information hold	11	prejudice	6.0	representative	2.0	investigate	4.0	datum use concern	5.0	park avenue south	1.0	upload	3.0	effort	6.0	sas	2.0	place	4.0
+168	suggestion	17.0	step	6.0	storytel	1.0	investigate	4.0	extent	6.0	storytel	1.0	investigate	4.0	step	6.0	skg	1.0	investigate	4.0	accord	10	type	6.0	business	2.0	adjust	4.0	support team	5.0	homer	1.0	access update	3.0	instance	6.0	apple	2.0	select	4.0
+169	control	17.0	customer	6.0	personal data protection commission	1.0	help	4.0	step	6.0	personal data protection commission	1.0	help	4.0	customer	6.0	storytel	1.0	help	4.0	company	10	effort	6.0	imo	2.0	block	4.0	dispute	5.0	support	1.0	investigate	3.0	work	6.0	bdsg	2.0	indicate	4.0
+170	order	17.0	description	6.0	social club	1.0	stop process	4.0	customer	6.0	social club	1.0	stop process	4.0	description	6.0	personal data protection commission	1.0	stop process	4.0	verify	10	notification	6.0	homer	2.0	head	4.0	day	5.0	amsterdam	1.0	block	3.0	residence	6.0	huuuges	2.0	have	4.0
+171	able	17.0	business	6.0	social point	1.0	adjust	4.0	description	6.0	social point	1.0	adjust	4.0	business	6.0	social club	1.0	adjust	4.0	profile	10	post	6.0	-urlor	2.0	raise	4.0	legislator	5.0	letsvpn	1.0	view update	3.0	unsubscribe	6.0	holborn	2.0	read	4.0
+172	file	16.0	paragraph	5.0	internet privacy policy	1.0	head	4.0	business	6.0	internet privacy policy	1.0	head	4.0	paragraph	5.0	social point	1.0	head	4.0	request deletion	10	instance	6.0	lion	2.0	place	4.0	existence	5.0	level	1.0	offer	3.0	feedback	6.0	denis	2.0	create	4.0
+173	addition	16.0	f	5.0	internet privacy policy administrator	1.0	raise	4.0	paragraph	5.0	internet privacy policy administrator	1.0	raise	4.0	f	5.0	internet privacy policy	1.0	raise	4.0	opt-out	10	residence	6.0	studios	2.0	select	4.0	method	5.0	lion??s data protection officer	1.0	continue process	3.0	method	6.0	saint	2.0	correspond	4.0
+174	query	16.0	alternative	5.0	eprivacy gmbh	1.0	access rectify	4.0	alternative	5.0	eprivacy gmbh	1.0	access rectify	4.0	alternative	5.0	internet privacy policy administrator	1.0	access rectify	4.0	page	10	work	6.0	musescore	2.0	indicate	4.0	date	5.0	medium	1.0	strive	3.0	enquiry	6.0	faubourg	2.0	load	3.0
+175	complain	16.0	profile page	5.0	prof	1.0	have	4.0	profile page	5.0	prof	1.0	have	4.0	profile page	5.0	eprivacy gmbh	1.0	have	4.0	inquiry	10	unsubscribe	6.0	civil	2.0	have	4.0	e	5.0	octaaf soudanstraat	1.0	review edit	3.0	mailing	6.0	tiktok	2.0	gather	3.0
+176	cookie	16.0	datum use concern	5.0	tandems	1.0	create	4.0	datum use concern	5.0	tandems	1.0	create	4.0	datum use concern	5.0	prof	1.0	create	4.0	complaint regard	10	feedback	6.0	settings	2.0	read	4.0	place	5.0	sint	1.0	indicate	3.0	extent	6.0	floor	2.0	replace	3.0
+177	message	16.0	dispute	5.0	chengdu sichuan china	1.0	correspond	4.0	dispute	5.0	tap4fun co. ltd	1.0	correspond	4.0	dispute	5.0	tandems	1.0	correspond	4.0	respond	10	method	6.0	rooster	2.0	create	4.0	confirmation	5.0	denijs	1.0	think	3.0	step	6.0	fireproof	2.0	cancel	3.0
+178	delay	15.0	office	5.0	tap4fun co. ltd	1.0	load	3.0	office	5.0	privacy administrator	1.0	load	3.0	office	5.0	tap4fun co. ltd	1.0	load	3.0	mail	10	mailing	6.0	teeth	2.0	correspond	4.0	communication	5.0	westrem	1.0	have	3.0	description	6.0	tw8	2.0	charge	3.0
+179	18	15.0	withdrawal	5.0	privacy administrator	1.0	replace	3.0	withdrawal	5.0	chengdu sichuan china	1.0	replace	3.0	withdrawal	5.0	privacy administrator	1.0	replace	3.0	contact detail provide	10	extent	6.0	productions	2.0	load	3.0	performance	5.0	belgium	1.0	add update	3.0	record	6.0	middlesex	2.0	pende	3.0
+180	inform	15.0	day	5.0	tianfu	1.0	cancel	3.0	day	5.0	tianfu	1.0	cancel	3.0	day	5.0	tianfu	1.0	cancel	3.0	explain	10	step	6.0	tx	2.0	gather	3.0	individual	5.0	california civil code	1.0	call	3.0	sharing	5.0	brentford	2.0	situate	3.0
+181	unless	15.0	legislator	5.0	ted sites	1.0	correct update	3.0	legislator	5.0	ted sites	1.0	correct update	3.0	legislator	5.0	chengdu sichuan china	1.0	correct update	3.0	stop use	9	description	6.0	e	2.0	replace	3.0	balancing	5.0	nekki limited	1.0	read	3.0	transfer	5.0	west	2.0	accept	3.0
+182	complete	15.0	existence	5.0	s el camino real suite	1.0	charge	3.0	existence	5.0	s el camino real suite	1.0	charge	3.0	existence	5.0	ted sites	1.0	charge	3.0	portability	9	sharing	5.0	austin	2.0	cancel	3.0	contract performance	5.0	art.18 gdpr	1.0	file	3.0	retention	5.0	great	2.0	encourage	3.0
+183	mobile	15.0	response	5.0	tile inc.	1.0	process pende	3.0	response	5.0	tile inc.	1.0	process pende	3.0	response	5.0	s el camino real suite	1.0	process pende	3.0	comply	9	transfer	5.0	51st	2.0	charge	3.0	period	5.0	nova geims ooo	1.0	fulfil	3.0	notification	5.0	tgtg	2.0	possess	3.0
+184	advertising	15.0	individual	5.0	san mateo	1.0	situate	3.0	performance	5.0	san mateo	1.0	situate	3.0	confirmation	5.0	tile inc.	1.0	situate	3.0	information provide	9	retention	5.0	belarus	2.0	pende	3.0	record	5.0	european data protection supervisor	1.0	compromise	3.0	alternative	5.0	t	2.0	upload	3.0
+185	security	15.0	balancing	5.0	privacy team thomson reuters	1.0	revise	3.0	individual	5.0	privacy team thomson reuters	1.0	revise	3.0	performance	5.0	san mateo	1.0	revise	3.0	objection	9	alternative	5.0	minsk	2.0	situate	3.0	service provider	5.0	outfit7	1.0	login	3.0	post	5.0	mortimer	2.0	deal	3.0
+186	profiling	15.0	contract performance	5.0	canary wharf london	1.0	assert	3.0	balancing	5.0	canary wharf london	1.0	assert	3.0	individual	5.0	privacy team thomson reuters	1.0	assert	3.0	guardian	9	resolution	5.0	topface	2.0	revise	3.0	identity	5.0	privacy policy notice	1.0	attempt	3.0	resolution	5.0	picsart	2.0	aim	3.0
+187	personally	15.0	period	5.0	statement	1.0	accept	3.0	contract performance	5.0	statement	1.0	accept	3.0	balancing	5.0	statement	1.0	accept	3.0	update information	9	department	5.0	rights	2.0	accept	3.0	datum processing	5.0	berliner beauftragte fr datenschutz	1.0	review delete	3.0	department	5.0	b66	2.0	strive	3.0
+188	list	14.0	service provider	5.0	data protection officer thomson reuters	1.0	destroy	3.0	period	5.0	data protection officer thomson reuters	1.0	destroy	3.0	contract performance	5.0	canary wharf london	1.0	destroy	3.0	access update	9	office	5.0	direct	2.0	destroy	3.0	marketing communication	5.0	informationsfreiheit	1.0	place	3.0	office	5.0	smethwick	2.0	remain	3.0
+189	contract	14.0	identity	5.0	canary wharf london e14	1.0	e	3.0	service provider	5.0	canary wharf london e14	1.0	e	3.0	period	5.0	data protection officer thomson reuters	1.0	encourage	3.0	site	9	withdrawal	5.0	irish	2.0	encourage	3.0	contact	5.0	section ii.i.1.d	1.0	suspend	2.0	day	5.0	roebuck	2.0	cover	3.0
+190	prevent	14.0	datum processing	5.0	twitch interactive inc.	1.0	encourage	3.0	identity	5.0	twitch interactive inc.	1.0	encourage	3.0	service provider	5.0	canary wharf london e14	1.0	possess	3.0	work	9	day	5.0	principles	2.0	possess	3.0	business purpose	5.0	autoriteit persoonsgegevens	1.0	defend	2.0	legislator	5.0	drogheda	2.0	fulfil	3.0
+191	feasible	14.0	marketing communication	5.0	twitch services	1.0	possess	3.0	datum processing	5.0	bush street	1.0	possess	3.0	identity	5.0	twitch interactive inc.	1.0	upload	3.0	allege infringement	9	legislator	5.0	camel	2.0	upload	3.0	transfer	4.0	hong kong law	1.0	involve	2.0	existence	5.0	lagavooren	2.0	compromise	3.0
+192	competent	14.0	contact	5.0	bush street	1.0	upload	3.0	marketing communication	5.0	twitch services	1.0	upload	3.0	datum processing	5.0	twitch services	1.0	access update	3.0	place	9	existence	5.0	market	2.0	deal	3.0	privacy question	4.0	legal protection	1.0	violate	2.0	menu	5.0	ring	2.0	login	3.0
+193	objection	14.0	business purpose	5.0	vertigo games sepapaja	1.0	access update	3.0	contact	5.0	vertigo games sepapaja	1.0	access update	3.0	marketing communication	5.0	bush street	1.0	deal	3.0	refer	9	menu	5.0	sas	2.0	aim	3.0	limitation	4.0	rosh ha ayin industrial zone israel	1.0	restore	2.0	statement	5.0	bull	2.0	attempt	3.0
+194	post	14.0	transfer	4.0	estonia	1.0	deal	3.0	business purpose	5.0	tallinn	1.0	deal	3.0	contact	5.0	vertigo games sepapaja	1.0	block	3.0	disclose	9	statement	5.0	rue	2.0	s	3.0	notification	4.0	microsoft	1.0	issue	2.0	response	5.0	boyne	2.0	reject	2.0
+195	country	14.0	privacy question	4.0	tallinn	1.0	block	3.0	transfer	4.0	estonia	1.0	block	3.0	business purpose	5.0	tallinn	1.0	view update	3.0	cookie	9	response	5.0	flaregames	2.0	strive	3.0	requirement	4.0	limited liability company swag masha	1.0	access correct	2.0	individual	5.0	governance	2.0	suspend	2.0
+196	resident	14.0	owner	4.0	contextlogic b.v.s	1.0	view update	3.0	privacy question	4.0	contextlogic b.v.s	1.0	view update	3.0	transfer	4.0	estonia	1.0	continue process	3.0	security	9	individual	5.0	bdsg	2.0	remain	3.0	regard	4.0	internatsionalnaya str	1.0	encourage	2.0	body	5.0	grci	2.0	defend	2.0
+197	number	14.0	dpo	4.0	netherlands data authority	1.0	continue process	3.0	owner	4.0	netherlands data authority	1.0	continue process	3.0	privacy question	4.0	contextlogic b.v.s	1.0	aim	3.0	obtain restriction	9	body	5.0	huuuges	2.0	cover	3.0	nature	4.0	republic	1.0	complete include	2.0	breach	5.0	management	2.0	lift	2.0
+198	notice	14.0	entity	4.0	technologies	1.0	aim	3.0	dpo	4.0	technologies	1.0	aim	3.0	owner	4.0	netherlands data authority	1.0	strive	3.0	establishment exercise	9	breach	5.0	cookie	2.0	act	3.0	post	4.0	support center	1.0	reset	2.0	rule	5.0	head	2.0	terminate	2.0
+199	games	14.0	limitation	4.0	data request portal	1.0	s	3.0	entity	4.0	data request portal	1.0	strive	3.0	dpo	4.0	technologies	1.0	remain	3.0	defense	9	rule	5.0	holborn	2.0	fulfil	3.0	profile setting	4.0	aurora ave woodstock ga	1.0	join	2.0	function	5.0	suntec	1.0	involve	2.0
+200	browser	13.0	notification	4.0	personal data request portal	1.0	strive	3.0	limitation	4.0	personal data request portal	1.0	remain	3.0	entity	4.0	data request portal	1.0	review edit	3.0	compliance	9	assistance	5.0	faubourg	2.0	compromise	3.0	fee	4.0	tastypill	1.0	deal	2.0	identity	5.0	temasek	1.0	oblige	2.0
+201	regulation	13.0	requirement	4.0	street san francisco	1.0	remain	3.0	notification	4.0	customer support page	1.0	review edit	3.0	limitation	4.0	personal data request portal	1.0	cover	3.0	record	9	function	5.0	saint	2.0	login	3.0	verification	4.0	testfoni	1.0	rectify erase	2.0	telephone	5.0	jagex	1.0	violate	2.0
+202	learn	13.0	nature	4.0	customer support page	1.0	review edit	3.0	requirement	4.0	zynga inc.	1.0	cover	3.0	notification	4.0	customer support page	1.0	add update	3.0	provision	9	identity	5.0	denis	2.0	attempt	3.0	residence place	4.0	topface	1.0	open	2.0	center	5.0	para	1.0	revise	2.0
+203	relation	13.0	regard	4.0	zynga inc.	1.0	cover	3.0	nature	4.0	street san francisco	1.0	add update	3.0	requirement	4.0	zynga inc.	1.0	call	3.0	issue	9	telephone	5.0	tiktok	2.0	reject	2.0	server	4.0	nicosia cyprus	1.0	aim	2.0	password	5.0	jaumos	1.0	restore	2.0
+204	set	13.0	profile setting	4.0	musixmatch	1.0	add update	3.0	regard	4.0	musixmatch	1.0	call	3.0	regard	4.0	street san francisco	1.0	select	3.0	notify	8	safeguard	5.0	floor	2.0	bring	2.0	datum protection law	4.0	boubolina	1.0	reside work	2.0	operation	5.0	lingodeer	1.0	instruct	2.0
+205	override	13.0	fee	4.0	authority	1.0	call	3.0	profile setting	4.0	authority	1.0	select	3.0	nature	4.0	musixmatch	1.0	read	3.0	prevent	8	center	5.0	england	2.0	suspend	2.0	party dispute resolution provider	4.0	information commissioners	1.0	connect	2.0	research	4.0	countriemay	1.0	instal	2.0
+206	shall	13.0	verification	4.0	protection	1.0	select	3.0	fee	4.0	protection	1.0	read	3.0	profile setting	4.0	authority	1.0	fulfil	3.0	oppose	8	operation	5.0	great	2.0	defend	2.0	permission	4.0	sunnyvale	1.0	appoint	2.0	limitation	4.0	designated	1.0	issue	2.0
+207	amend	13.0	residence place	4.0	personal information protection act	1.0	read	3.0	verification	4.0	personal information protection act	1.0	fulfil	3.0	fee	4.0	protection	1.0	compromise	3.0	freedom	8	research	4.0	west	2.0	lift	2.0	department	4.0	california privacy rights	1.0	supervise	2.0	requirement	4.0	livu	1.0	destroy	2.0
+208	provider	13.0	server	4.0	gdask poland	1.0	fulfil	3.0	residence place	4.0	zacna	1.0	compromise	3.0	verification	4.0	personal information protection act	1.0	login	3.0	recipient	8	dpo	4.0	brentford	2.0	terminate	2.0	office	4.0	privacy tubi inc	1.0	keep	2.0	nature	4.0	clara	1.0	e	2.0
+209	mean	13.0	datum protection law	4.0	street	1.0	compromise	3.0	server	4.0	street	1.0	login	3.0	residence place	4.0	zacna	1.0	attempt	3.0	product	8	entity	4.0	middlesex	2.0	oblige	2.0	withdrawal	4.0	montgomery street	1.0	possess	2.0	regard	4.0	santa	1.0	reset	2.0
+210	retain	13.0	party dispute resolution provider	4.0	zacna	1.0	login	3.0	datum protection law	4.0	gdask poland	1.0	attempt	3.0	server	4.0	street	1.0	review delete	3.0	choose	8	limitation	4.0	tw8	2.0	involve	2.0	registration	4.0	twitter inc	1.0	publish	2.0	photo	4.0	circle	1.0	join	2.0
+211	activity	13.0	feedback	4.0	app	1.0	attempt	3.0	party dispute resolution provider	4.0	app	1.0	review delete	3.0	datum protection law	4.0	gdask poland	1.0	place	3.0	withdraw consent	8	requirement	4.0	mcdonald	2.0	violate	2.0	datum subject	4.0	twitter	1.0	correct update amend	2.0	fee	4.0	freedom	1.0	open	2.0
+212	instruction	13.0	permission	4.0	camsurf	1.0	review delete	3.0	feedback	4.0	camsurf	1.0	place	3.0	party dispute resolution provider	4.0	app	1.0	gather	2.0	forget	8	nature	4.0	freeview	2.0	restore	2.0	handling	4.0	principles	1.0	accommodate	2.0	verification	4.0	laws	1.0	connect	2.0
+213	help	13.0	department	4.0	carx technologies limited	1.0	place	3.0	permission	4.0	carx technologies limited	1.0	gather	2.0	feedback	4.0	camsurf	1.0	reject	2.0	office	8	regard	4.0	t	2.0	instruct	2.0	error	4.0	jams	1.0	alert	2.0	server	4.0	mobisystems	1.0	supervise	2.0
+214	emailand	13.0	registration	4.0	user experience improvement program location access	1.0	gather	2.0	department	4.0	user experience improvement program location access	1.0	reject	2.0	permission	4.0	carx technologies limited	1.0	bring	2.0	live	8	photo	4.0	mortimer	2.0	instal	2.0	statement	4.0	site applications	1.0	reserve	2.0	state	4.0	flurry	1.0	keep	2.0
+215	business	13.0	datum subject	4.0	mi account	1.0	reject	2.0	registration	4.0	mi account	1.0	bring	2.0	department	4.0	user experience improvement program location access	1.0	suspend	2.0	choice	8	fee	4.0	picsart	2.0	issue	2.0	block	4.0	services	1.0	communicate	2.0	permission	4.0	partners	1.0	publish	2.0
+216	add	12.0	handling	4.0	bluehole pnix	1.0	bring	2.0	datum subject	4.0	bluehole pnix	1.0	suspend	2.0	registration	4.0	mi account	1.0	defend	2.0	instruction	8	verification	4.0	roebuck	2.0	reset	2.0	service support	4.0	google play /apple app store	1.0	dispute	2.0	process	4.0	twitters	1.0	accommodate	2.0
+217	accord	12.0	error	4.0	european economic area canada costa rica	1.0	suspend	2.0	handling	4.0	european economic area canada costa rica	1.0	defend	2.0	datum subject	4.0	bluehole pnix	1.0	lift	2.0	california resident	8	server	4.0	smethwick	2.0	join	2.0	response	4.0	ellation inc.	1.0	understand	2.0	experience	4.0	kg	1.0	alert	2.0
+218	inaccuracy	12.0	statement	4.0	discord	1.0	defend	2.0	error	4.0	discord	1.0	lift	2.0	handling	4.0	european economic area canada costa rica	1.0	terminate	2.0	example	8	state	4.0	b66	2.0	designate	2.0	datum portability	4.0	market st	1.0	produce	2.0	withdrawal	4.0	solutions	1.0	communicate	2.0
+219	public	12.0	block	4.0	lockhart ro wan chai h.k	1.0	lift	2.0	statement	4.0	lockhart ro wan chai h.k	1.0	terminate	2.0	error	4.0	discord	1.0	oblige	2.0	violation	8	permission	4.0	drogheda	2.0	open	2.0	abuse	4.0	rue pierre picard	1.0	obligate	2.0	procedure	4.0	carly	1.0	dispute	2.0
+220	technically	12.0	service support	4.0	rm	1.0	terminate	2.0	block	4.0	lockhart	1.0	oblige	2.0	statement	4.0	lockhart ro wan chai h.k	1.0	involve	2.0	view	8	process	4.0	head	2.0	connect	2.0	body	4.0	dashlane sas	1.0	select	2.0	point	4.0	alliances	1.0	understand	2.0
+221	dpo	12.0	datum portability	4.0	lockhart	1.0	involve	2.0	service support	4.0	rm	1.0	involve	2.0	block	4.0	lockhart	1.0	violate	2.0	question concern	8	experience	4.0	management	2.0	supervise	2.0	category	4.0	advertising id	1.0	report	2.0	handling	4.0	ecuries	1.0	produce	2.0
+222	enable	12.0	confirmation	4.0	clicktouch games	1.0	oblige	2.0	datum portability	4.0	clicktouch games	1.0	violate	2.0	service support	4.0	rm	1.0	restore	2.0	profiling	8	procedure	4.0	grci	2.0	keep	2.0	function	4.0	apple ios	1.0	endeavour	2.0	error	4.0	petites	1.0	obligate	2.0
+223	unlawfully	12.0	performance	4.0	dvapps ab	1.0	violate	2.0	confirmation	4.0	dvapps ab	1.0	restore	2.0	datum portability	4.0	clicktouch games	1.0	instruct	2.0	processing activity	8	point	4.0	governance	2.0	publish	2.0	end	4.0	google android	1.0	play	2.0	block	4.0	des	1.0	hear	2.0
+224	person	12.0	abuse	4.0	dvloper	1.0	restore	2.0	abuse	4.0	dvloper	1.0	instruct	2.0	abuse	4.0	dvapps ab	1.0	instal	2.0	disable	7	handling	4.0	boyne	2.0	accommodate	2.0	explanation	4.0	california civil code section	1.0	prefer	2.0	id	4.0	r2games	1.0	endeavour	2.0
+225	site	12.0	body	4.0	limassol cyprus	1.0	instruct	2.0	body	4.0	krinou street	1.0	instal	2.0	body	4.0	dvloper	1.0	issue	2.0	base	7	error	4.0	bull	2.0	alert	2.0	list	4.0	state	1.0	correct delete	2.0	analytic	4.0	club	1.0	play	2.0
+226	registration	12.0	effect	4.0	easybrain ltd	1.0	instal	2.0	effect	4.0	easybrain ltd	1.0	issue	2.0	assistance	4.0	krinou street	1.0	e	2.0	entitle	7	block	4.0	ring	2.0	reserve	2.0	question concern	4.0	duolingo	1.0	restrict stop	2.0	technology	4.0	point	1.0	prefer	2.0
+227	work	12.0	assistance	4.0	krinou street	1.0	de	2.0	assistance	4.0	limassol cyprus	1.0	access correct	2.0	problem	4.0	easybrain ltd	1.0	access correct	2.0	datum delete	7	id	4.0	lagavooren	2.0	communicate	2.0	exercise	4.0	bbb eu privacy shield	1.0	fix	2.0	line	4.0	prof	1.0	fix	2.0
+228	infringement	12.0	problem	4.0	oval	1.0	issue	2.0	problem	4.0	oval	1.0	complete include	2.0	category	4.0	limassol cyprus	1.0	complete include	2.0	datum controller	7	analytic	4.0	netflix	2.0	dispute	2.0	interaction	4.0	data protection	1.0	cease	2.0	abuse	4.0	eprivacy	1.0	vary	2.0
+229	place	12.0	category	4.0	technopark perm	1.0	access correct	2.0	category	4.0	technopark perm	1.0	reset	2.0	function	4.0	oval	1.0	reset	2.0	machine	7	technology	4.0	temasek	1.0	understand	2.0	help service	4.0	stockholm sweden	1.0	stay	2.0	demand	4.0	tandem	1.0	stay	2.0
+230	associate	12.0	function	4.0	stakhanovskaya	1.0	complete include	2.0	function	4.0	stakhanovskaya	1.0	join	2.0	end	4.0	technopark perm	1.0	join	2.0	ico	7	line	4.0	suntec	1.0	produce	2.0	drawer	4.0	brunnsgatan	1.0	invoke	2.0	assistance	4.0	china	1.0	invoke	2.0
+231	online	12.0	end	4.0	company	1.0	reset	2.0	end	4.0	company	1.0	rectify erase	2.0	explanation	4.0	stakhanovskaya	1.0	rectify erase	2.0	datum collect	7	abuse	4.0	jagex	1.0	obligate	2.0	sharing	3.0	gametion technologies pvt ltd	1.0	live work	2.0	category	4.0	sichuan	1.0	welcome	2.0
+232	inquiry	12.0	explanation	4.0	findnow	1.0	join	2.0	explanation	4.0	findnow	1.0	designate	2.0	list	4.0	company	1.0	designate	2.0	option	7	demand	4.0	para	1.0	hear	2.0	browser setting	3.0	eu representative	1.0	serve	2.0	making	4.0	tianfu	1.0	solve	2.0
+233	communication	12.0	list	4.0	strovolos nicosia cyprus	1.0	rectify erase	2.0	list	4.0	strovolos avenue petousis	1.0	open	2.0	question concern	4.0	findnow	1.0	open	2.0	manage	7	problem	4.0	jaumos	1.0	endeavour	2.0	agreement	3.0	liverpool street london ec2 m	1.0	correspond	2.0	end	4.0	chengdu	1.0	serve	2.0
+234	view	12.0	question concern	4.0	strovolos avenue petousis	1.0	designate	2.0	question concern	4.0	strovolos nicosia cyprus	1.0	reside work	2.0	exercise	4.0	strovolos avenue petousis	1.0	reside work	2.0	export	7	category	4.0	apps	1.0	play	2.0	remedy	3.0	dpo centre	1.0	depend	2.0	explanation	4.0	co.	1.0	depend	2.0
+235	20	11.0	exercise	4.0	personal data protection	1.0	open	2.0	exercise	4.0	personal data protection	1.0	connect	2.0	clause	4.0	strovolos nicosia cyprus	1.0	connect	2.0	amend	7	making	4.0	designated	1.0	prefer	2.0	customer service	3.0	gogogame	1.0	detail	2.0	web	4.0	tap4fun	1.0	detail	2.0
+236	21	11.0	clause	4.0	commissioner	1.0	reside work	2.0	clause	4.0	commissioner	1.0	supervise	2.0	preference	4.0	personal data protection	1.0	supervise	2.0	browser	7	end	4.0	countriemay	1.0	fix	2.0	game setting	3.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0	perform	2.0	clause	4.0	ted	1.0	assist	2.0
+237	eea	11.0	preference	4.0	legal	1.0	connect	2.0	preference	4.0	legal	1.0	keep	2.0	safeguard	4.0	commissioner	1.0	keep	2.0	writing	7	explanation	4.0	freedom	1.0	vary	2.0	owner	3.0	beechavenue	1.0	assist	2.0	interaction	4.0	sites	1.0	perform	2.0
+238	term	11.0	safeguard	4.0	genera games s.l cardenal bueno monreal	1.0	supervise	2.0	safeguard	4.0	genera games s.l cardenal bueno monreal	1.0	publish	2.0	interaction	4.0	legal	1.0	publish	2.0	agree	7	web	4.0	circle	1.0	stay	2.0	hindrance	3.0	schiphol	1.0	modify update	2.0	drawer	4.0	mateo	1.0	search	2.0
+239	disclosure	11.0	interaction	4.0	sevilla spain	1.0	keep	2.0	interaction	4.0	sevilla spain	1.0	correct update amend	2.0	help service	4.0	genera games s.l cardenal bueno monreal	1.0	correct update amend	2.0	process base	7	clause	4.0	santa	1.0	invoke	2.0	dpo	3.0	rijk	1.0	record	2.0	agreement	3.0	real	1.0	say	2.0
+240	verify	11.0	help service	4.0	planta	1.0	publish	2.0	help service	4.0	planta	1.0	accommodate	2.0	letter	4.0	sevilla spain	1.0	accommodate	2.0	contest	7	interaction	4.0	clara	1.0	solve	2.0	protection	3.0	data privacy officer	1.0	execute	2.0	remedy	3.0	tile	1.0	hope	2.0
+241	permit	11.0	letter	4.0	geozilla	1.0	correct update amend	2.0	letter	4.0	geozilla	1.0	alert	2.0	drawer	4.0	planta	1.0	alert	2.0	european union	7	password	4.0	laws	1.0	serve	2.0	para	3.0	office ofdata protection	1.0	constitute	2.0	version	3.0	camino	1.0	supply	2.0
+242	possible	11.0	drawer	4.0	microsoft chief privacy officer	1.0	accommodate	2.0	drawer	4.0	eu data protection officer	1.0	communicate	2.0	browser setting	3.0	geozilla	1.0	communicate	2.0	jurisdiction	7	drawer	4.0	mobisystems	1.0	depend	2.0	entry	3.0	huuuges	1.0	pursue	2.0	hindrance	3.0	el	1.0	record	2.0
+243	consider	11.0	browser setting	3.0	eu data protection officer	1.0	alert	2.0	browser setting	3.0	microsoft chief privacy officer	1.0	dispute	2.0	sharing	3.0	microsoft chief privacy officer	1.0	dispute	2.0	notice	7	agreement	3.0	flurry	1.0	detail	2.0	effort	3.0	president	1.0	protect	2.0	dpo	3.0	e14	1.0	execute	2.0
+244	undue	11.0	sharing	3.0	healthvault	1.0	communicate	2.0	sharing	3.0	healthvault	1.0	understand	2.0	agreement	3.0	eu data protection officer	1.0	understand	2.0	ability	7	remedy	3.0	mopubs	1.0	fill	2.0	avatar	3.0	huuuge	1.0	result	1.0	para	3.0	twitch	1.0	constitute	2.0
+245	charge	11.0	agreement	3.0	instagram	1.0	dispute	2.0	agreement	3.0	instagram	1.0	produce	2.0	remedy	3.0	healthvault	1.0	produce	2.0	contract	7	version	3.0	partners	1.0	assist	2.0	privacy right	3.0	huuugegroup	1.0	gather	1.0	entry	3.0	estonia	1.0	pursue	2.0
+246	preference	11.0	remedy	3.0	customer center	1.0	understand	2.0	remedy	3.0	customer center	1.0	obligate	2.0	customer service	3.0	instagram	1.0	obligate	2.0	allow	7	hindrance	3.0	twitters	1.0	perform	2.0	photo	3.0	huuuge games sp	1.0	reject	1.0	avatar	3.0	tallinn	1.0	act	2.0
+247	link	11.0	customer service	3.0	privacy protection department	1.0	produce	2.0	customer service	3.0	netmarble	1.0	endeavour	2.0	game setting	3.0	customer center	1.0	endeavour	2.0	download	7	para	3.0	kg	1.0	search	2.0	newsletter	3.0	twitter inc.	1.0	impact	1.0	regulation	3.0	sepapaja	1.0	sell	2.0
+248	dispute	11.0	game setting	3.0	netmarble	1.0	obligate	2.0	game setting	3.0	privacy protection department	1.0	play	2.0	version	3.0	netmarble	1.0	play	2.0	question relate	6	entry	3.0	carly	1.0	say	2.0	feedback	3.0	data protection officerone cumberland place fenian streetdublin	1.0	assert exercise	1.0	forum	3.0	vertigo	1.0	adapt	1.0
+249	google	11.0	version	3.0	yazio	1.0	endeavour	2.0	version	3.0	yazio	1.0	prefer	2.0	hindrance	3.0	privacy protection department	1.0	prefer	2.0	letter	6	avatar	3.0	solutions	1.0	hope	2.0	display	3.0	market street suite 900san francisco	1.0	terminate	1.0	display	3.0	b.v.s	1.0	result	1.0
+250	locate	11.0	hindrance	3.0	eu local representative	1.0	play	2.0	hindrance	3.0	eu local representative	1.0	correct delete	2.0	protection	3.0	yazio	1.0	correct delete	2.0	prejudice	6	newsletter	3.0	paypal	1.0	exist	2.0	exemption	3.0	ireland	1.0	oblige	1.0	entity	3.0	contextlogic	1.0	govern	1.0
+251	register	11.0	protection	3.0	icbc business	1.0	prefer	2.0	protection	3.0	icbc business	1.0	restrict stop	2.0	para	3.0	eu local representative	1.0	restrict stop	2.0	data protection law	6	regulation	3.0	alliances	1.0	supply	2.0	number	3.0	twitter international companys	1.0	breach	1.0	exemption	3.0	zynga	1.0	dedicate	1.0
+252	california	11.0	para	3.0	icbc mobile banking	1.0	correct delete	2.0	para	3.0	icbc mobile banking	1.0	fix	2.0	entry	3.0	icbc business	1.0	fix	2.0	type	6	forum	3.0	petites	1.0	record	2.0	account setting section	3.0	tricor	1.0	age	1.0	cost	3.0	page	1.0	oversee	1.0
+253	disclose	11.0	entry	3.0	user information policy	1.0	restrict stop	2.0	entry	3.0	user information policy	1.0	stay	2.0	effort	3.0	icbc mobile banking	1.0	stay	2.0	continue	6	display	3.0	ecuries	1.0	execute	2.0	advertising experience	3.0	mark lane london	1.0	manage review	1.0	employee	3.0	overmobile	1.0	impact	1.0
+254	example	11.0	effort	3.0	bank	1.0	fix	2.0	effort	3.0	bank	1.0	invoke	2.0	avatar	3.0	user information policy	1.0	invoke	2.0	member state	6	exemption	3.0	des	1.0	constitute	2.0	procedure	3.0	saygames llc	1.0	asus	1.0	faith	3.0	poland	1.0	breach	1.0
+255	street	11.0	avatar	3.0	imo	1.0	stay	2.0	avatar	3.0	imo	1.0	live work	2.0	privacy right	3.0	bank	1.0	live work	2.0	eea	6	cost	3.0	flow	1.0	pursue	2.0	employee	3.0	addressable platform limited	1.0	process concern	1.0	answer	3.0	gdask	1.0	age	1.0
+256	explain	11.0	privacy right	3.0	imo s	1.0	invoke	2.0	privacy right	3.0	imo s	1.0	serve	2.0	photo	3.0	imo	1.0	serve	2.0	instance	6	employee	3.0	r2games	1.0	sell	2.0	controller restriction	3.0	itv	1.0	discontinue receive	1.0	legislation	3.0	zacna	1.0	asus	1.0
+257	center	11.0	photo	3.0	keeper security	1.0	live work	2.0	photo	3.0	keeper security	1.0	depend	2.0	newsletter	3.0	imo s	1.0	depend	2.0	permit	6	faith	3.0	rules	1.0	adapt	1.0	point	3.0	britbox	1.0	navigate	1.0	administrator	3.0	app	1.0	discontinue	1.0
+258	twitter	11.0	newsletter	3.0	thinking ape entertainment ltd	1.0	serve	2.0	newsletter	3.0	thinking ape entertainment ltd	1.0	detail	2.0	access request	3.0	keeper security	1.0	detail	2.0	hesitate	6	answer	3.0	relive	1.0	result	1.0	faith effort	3.0	itv rights limited	1.0	adopt	1.0	database	3.0	carx	1.0	navigate	1.0
+259	entitle	10.0	access request	3.0	planb labs	1.0	depend	2.0	access request	3.0	planb labs	1.0	fill	2.0	display	3.0	thinking ape entertainment ltd	1.0	fill	2.0	access modify	6	legislation	3.0	skg	1.0	govern	1.0	device setting	3.0	itv consumer limited	1.0	revoke	1.0	offer	3.0	mi	1.0	adopt	1.0
+260	tool	10.0	display	3.0	park avenue south	1.0	detail	2.0	display	3.0	park avenue south	1.0	perform	2.0	exemption	3.0	planb labs	1.0	perform	2.0	profile information	6	administrator	3.0	storytel	1.0	dedicate	1.0	technology	3.0	holborn london ec1n	1.0	call opt	1.0	effect	3.0	access	1.0	revoke	1.0
+261	ico	10.0	exemption	3.0	ny ny	1.0	fill	2.0	exemption	3.0	ny ny	1.0	assist	2.0	cost	3.0	park avenue south	1.0	assist	2.0	privacy officer	6	building	3.0	club	1.0	oversee	1.0	advertising	3.0	fremantle media limited	1.0	reply	1.0	ofinterest	3.0	location	1.0	reply	1.0
+262	uk	10.0	cost	3.0	amsterdam	1.0	perform	2.0	cost	3.0	support	1.0	say	2.0	number	3.0	ny ny	1.0	say	2.0	united kingdom	6	database	3.0	point	1.0	impact	1.0	line	3.0	stephen street london w1 t	1.0	replace	1.0	modification	3.0	program	1.0	disconnect	1.0
+263	freedom	10.0	number	3.0	support	1.0	assist	2.0	number	3.0	amsterdam	1.0	hope	2.0	account setting section	3.0	support	1.0	hope	2.0	united states	6	agent	3.0	prof	1.0	exclude	1.0	mailing list	3.0	waterhouse square	1.0	revise	1.0	functionality	3.0	improvement	1.0	appear	1.0
+264	guardian	10.0	account setting section	3.0	letsvpn	1.0	say	2.0	account setting section	3.0	letsvpn	1.0	modify update	2.0	advertising experience	3.0	amsterdam	1.0	modify update	2.0	data subject	6	offer	3.0	eprivacy	1.0	breach	1.0	phone	3.0	got talent	1.0	appear	1.0	login	3.0	experience	1.0	realize	1.0
+265	manage	10.0	advertising experience	3.0	level	1.0	hope	2.0	advertising experience	3.0	level	1.0	exist	2.0	procedure	3.0	letsvpn	1.0	exist	2.0	method	6	effect	3.0	tandems	1.0	age	1.0	database	3.0	x factor	1.0	forget	1.0	channel	3.0	pnix	1.0	uninstall	1.0
+266	choose	10.0	procedure	3.0	lima sky	1.0	modify update	2.0	procedure	3.0	lima sky	1.0	supply	2.0	employee	3.0	level	1.0	supply	2.0	state	6	ofinterest	3.0	china	1.0	asus	1.0	offer	3.0	britain	1.0	realize	1.0	approach	3.0	bluehole	1.0	represent	1.0
+267	unsubscribe	10.0	employee	3.0	lion	1.0	exist	2.0	employee	3.0	lion	1.0	record	2.0	controller restriction	3.0	lima sky	1.0	record	2.0	supplement	6	functionality	3.0	sichuan	1.0	discontinue	1.0	setting page	3.0	gb	1.0	uninstall	1.0	partner	3.0	rica	1.0	hide	1.0
+268	ca	10.0	controller restriction	3.0	lion studios	1.0	supply	2.0	controller restriction	3.0	lion studios	1.0	execute	2.0	point	3.0	lion	1.0	execute	2.0	inaccuracy	6	modification	3.0	tap4fun	1.0	navigate	1.0	breach	3.0	hydrane sas	1.0	include delete	1.0	personal	3.0	costa	1.0	endeavor	1.0
+269	department	10.0	point	3.0	lion??s data protection officer	1.0	record	2.0	point	3.0	lion??s data protection officer	1.0	constitute	2.0	faith effort	3.0	lion studios	1.0	constitute	2.0	year	6	login	3.0	co.	1.0	incur	1.0	effect	3.0	denis	1.0	edit hide	1.0	delivery	3.0	canada	1.0	escalate	1.0
+270	area	10.0	faith effort	3.0	octaaf soudanstraat	1.0	execute	2.0	faith effort	3.0	octaaf soudanstraat	1.0	pursue	2.0	device setting	3.0	lion??s data protection officer	1.0	pursue	2.0	carry	6	channel	3.0	tianfu	1.0	adopt	1.0	demand	3.0	paris	1.0	endeavor	1.0	driver	3.0	h.k	1.0	turn	1.0
+271	united	10.0	device setting	3.0	sint	1.0	constitute	2.0	device setting	3.0	sint	1.0	act	2.0	answer	3.0	octaaf soudanstraat	1.0	act	2.0	unsubscribe	6	approach	3.0	chengdu	1.0	reply	1.0	support service	3.0	denis paris france	1.0	collect process	1.0	deactivation	3.0	chai	1.0	disassociate	1.0
+272	date	10.0	answer	3.0	westrem	1.0	pursue	2.0	answer	3.0	denijs	1.0	adapt	1.0	technology	3.0	sint	1.0	adapt	1.0	offer	6	personal	3.0	ted	1.0	disconnect	1.0	ofinterest rule	3.0	rue	1.0	turn	1.0	-emailor	3.0	wan	1.0	lose	1.0
+273	refer	10.0	technology	3.0	belgium	1.0	act	2.0	technology	3.0	westrem	1.0	result	1.0	advertising	3.0	denijs	1.0	result	1.0	extent	6	partner	3.0	sites	1.0	appear	1.0	support form	3.0	companyabout games blog jobs	1.0	place delete	1.0	book	3.0	ro	1.0	employ	1.0
+274	respond	10.0	advertising	3.0	denijs	1.0	adapt	1.0	advertising	3.0	belgium	1.0	govern	1.0	line	3.0	westrem	1.0	govern	1.0	head	6	delivery	3.0	tile	1.0	realize	1.0	profile section	3.0	games articles	1.0	include disassociate	1.0	safety	3.0	lockhart	1.0	achieve	1.0
+275	soon	10.0	line	3.0	california civil code	1.0	result	1.0	line	3.0	california civil code	1.0	dedicate	1.0	mailing list	3.0	belgium	1.0	dedicate	1.0	report	6	driver	3.0	el	1.0	uninstall	1.0	datum storage	3.0	twitter facebook linkedin	1.0	lose	1.0	safeguard	3.0	rm	1.0	determine	1.0
+276	specific	10.0	mailing list	3.0	art.18 gdpr	1.0	govern	1.0	mailing list	3.0	art.18 gdpr	1.0	oversee	1.0	administrator	3.0	california civil code	1.0	oversee	1.0	tool	6	payment	3.0	camino	1.0	represent	1.0	privacy setting	3.0	events careers	1.0	employ	1.0	keyword	2.0	clicktouch	1.0	undertake	1.0
+277	london	10.0	administrator	3.0	nova geims ooo	1.0	dedicate	1.0	administrator	3.0	nova geims ooo	1.0	impact	1.0	phone	3.0	art.18 gdpr	1.0	impact	1.0	disclosure	6	deactivation	3.0	real	1.0	hide	1.0	support page	3.0	tiktok inc	1.0	block delete	1.0	pre	2.0	ab	1.0	quote	1.0
+278	services	10.0	phone	3.0	european data protection supervisor	1.0	oversee	1.0	phone	3.0	european data protection supervisor	1.0	assert exercise	1.0	database	3.0	nova geims ooo	1.0	assert exercise	1.0	customer	6	-emailor	3.0	mateo	1.0	endeavor	1.0	officer	3.0	tiktok legal department	1.0	object apply	1.0	hinderance	2.0	dvapps	1.0	s	1.0
+279	condition	9.0	database	3.0	outfit7	1.0	impact	1.0	database	3.0	outfit7	1.0	exclude	1.0	offer	3.0	european data protection supervisor	1.0	exclude	1.0	information base	6	safety	3.0	e14	1.0	escalate	1.0	functionality	3.0	venice blvd suite	1.0	correct complete	1.0	advertisement	2.0	dvloper	1.0	remember	1.0
+280	continue	9.0	offer	3.0	privacy policy notice	1.0	assert exercise	1.0	offer	3.0	privacy policy notice	1.0	breach	1.0	setting page	3.0	outfit7	1.0	breach	1.0	description	6	keyword	2.0	twitch	1.0	turn	1.0	modification	3.0	culver city	1.0	achieve	1.0	appeal	2.0	limassol	1.0	define	1.0
+281	comply	9.0	setting page	3.0	berliner beauftragte fr datenschutz	1.0	exclude	1.0	setting page	3.0	berliner beauftragte fr datenschutz	1.0	age	1.0	breach	3.0	privacy policy notice	1.0	age	1.0	business	6	pre	2.0	vertigo	1.0	disassociate	1.0	mailing address	3.0	usaemail	1.0	determine	1.0	aspect	2.0	oval	1.0	outweigh	1.0
+282	option	9.0	breach	3.0	informationsfreiheit	1.0	breach	1.0	breach	3.0	informationsfreiheit	1.0	manage review	1.0	effect	3.0	berliner beauftragte fr datenschutz	1.0	manage review	1.0	refuse	6	hinderance	2.0	sepapaja	1.0	lose	1.0	setting section	3.0	policy	1.0	raise	1.0	exception	2.0	krinou	1.0	abide	1.0
+283	recipient	9.0	demand	3.0	kwalee	1.0	age	1.0	demand	3.0	kwalee	1.0	asus	1.0	demand	3.0	informationsfreiheit	1.0	asus	1.0	information concern	6	advertisement	2.0	tallinn	1.0	employ	1.0	data practice	3.0	october	1.0	undertake	1.0	membership	2.0	easybrain	1.0	redirect	1.0
+284	team	9.0	support service	3.0	section ii.i.1.d	1.0	manage review	1.0	support service	3.0	section ii.i.1.d	1.0	process concern	1.0	support service	3.0	kwalee	1.0	process concern	1.0	date	6	appeal	2.0	estonia	1.0	achieve	1.0	web form	3.0	bytedance uk limited aviation house	1.0	select remove	1.0	duration	2.0	perm	1.0	renew	1.0
+285	electronic	9.0	ofinterest rule	3.0	autoriteit persoonsgegevens	1.0	asus	1.0	ofinterest rule	3.0	autoriteit persoonsgegevens	1.0	discontinue receive	1.0	ofinterest rule	3.0	section ii.i.1.d	1.0	discontinue receive	1.0	list	6	aspect	2.0	contextlogic	1.0	determine	1.0	marketing processing	3.0	kingsway holborn london wc2b	1.0	automate process include	1.0	delete	2.0	technopark	1.0	justify	1.0
+286	emailwith	9.0	support form	3.0	hong kong law	1.0	process concern	1.0	support form	3.0	hong kong law	1.0	navigate	1.0	support form	3.0	autoriteit persoonsgegevens	1.0	navigate	1.0	try	6	exception	2.0	b.v.s	1.0	undertake	1.0	update information	3.0	summarywhat	1.0	define	1.0	newsletter	2.0	stakhanovskaya	1.0	reserve	1.0
+287	allege	9.0	profile section	3.0	legal protection	1.0	discontinue receive	1.0	profile section	3.0	legal protection	1.0	incur	1.0	profile section	3.0	hong kong law	1.0	incur	1.0	cease	6	membership	2.0	zynga	1.0	quote	1.0	interest right	3.0	product availability alerts delivers	1.0	outweigh	1.0	portal	2.0	findnow	1.0	realise	1.0
+288	live	9.0	privacy officer	3.0	rosh ha ayin industrial zone israel	1.0	navigate	1.0	privacy officer	3.0	rosh ha ayin industrial zone israel	1.0	adopt	1.0	privacy officer	3.0	legal protection	1.0	adopt	1.0	restrict access	6	duration	2.0	page	1.0	remember	1.0	approach	3.0	recommendations listmania	1.0	include base	1.0	scope	2.0	strovolos	1.0	recover	1.0
+289	economic	9.0	datum storage	3.0	diandian	1.0	incur	1.0	datum storage	3.0	diandian	1.0	call opt	1.0	datum storage	3.0	rosh ha ayin industrial zone israel	1.0	call opt	1.0	doubleugames account	6	delete	2.0	musixmatch	1.0	define	1.0	clause	3.0	wish list	1.0	abide	1.0	visitor	2.0	petousis	1.0	plan	1.0
+290	offer	9.0	privacy setting	3.0	microsoft	1.0	adopt	1.0	privacy setting	3.0	microsoft	1.0	reply	1.0	privacy setting	3.0	diandian	1.0	reply	1.0	support	6	portal	2.0	poland	1.0	outweigh	1.0	personal information	3.0	recommended	1.0	redirect	1.0	testimonial	2.0	sevilla	1.0	disagree	1.0
+291	statement	9.0	support page	3.0	game id	1.0	call opt	1.0	support page	3.0	game id	1.0	disconnect	1.0	support page	3.0	microsoft	1.0	disconnect	1.0	add	5	scope	2.0	gdask	1.0	abide	1.0	preference	3.0	lists	1.0	renew correct	1.0	correct	2.0	planta	1.0	inquire	1.0
+292	appropriate	9.0	modification	3.0	limited liability company swag masha	1.0	reply	1.0	functionality	3.0	limited liability company swag masha	1.0	appear	1.0	functionality	3.0	game id	1.0	appear	1.0	meet	5	visitor	2.0	zacna	1.0	redirect	1.0	registration number	3.0	baby	1.0	justify	1.0	mobile	2.0	spain	1.0	come	1.0
+293	welcome	9.0	functionality	3.0	internatsionalnaya str	1.0	disconnect	1.0	modification	3.0	republic	1.0	realize	1.0	modification	3.0	limited liability company swag masha	1.0	realize	1.0	handle	5	testimonial	2.0	camsurf	1.0	renew	1.0	support e	3.0	wedding	1.0	realise	1.0	add	2.0	monreal	1.0	retrieve	1.0
+294	download	9.0	mailing address	3.0	republic	1.0	appear	1.0	mailing address	3.0	internatsionalnaya str	1.0	uninstall	1.0	mailing address	3.0	republic	1.0	uninstall	1.0	dpo	5	correct	2.0	carx	1.0	justify	1.0	letter	3.0	profile	1.0	gather edit add	1.0	association	2.0	bueno	1.0	authorize	1.0
+295	violation	9.0	setting section	3.0	aurora ave woodstock ga	1.0	realize	1.0	setting section	3.0	aurora ave woodstock ga	1.0	include delete	1.0	setting section	3.0	internatsionalnaya str	1.0	include delete	1.0	appoint	5	mobile	2.0	mi	1.0	realise	1.0	regulator	3.0	hays house north wing	1.0	recover	1.0	destruction	2.0	cardenal	1.0	-emailuse	1.0
+296	10	9.0	data practice	3.0	tastypill	1.0	uninstall	1.0	data practice	3.0	tastypill	1.0	represent	1.0	data practice	3.0	aurora ave woodstock ga	1.0	represent	1.0	check	5	add	2.0	experience	1.0	recover	1.0	provider	3.0	floor millmead guildford surrey england gu2 4hj	1.0	review correct	1.0	summary	2.0	s.l	1.0	consult	1.0
+297	defense	9.0	web form	3.0	telegram	1.0	include delete	1.0	web form	3.0	telegram	1.0	edit hide	1.0	web form	3.0	tastypill	1.0	edit hide	1.0	request erasure	5	association	2.0	improvement	1.0	plan	1.0	privacy law	3.0	contact information	1.0	plan	1.0	promotion	2.0	genera	1.0	forward	1.0
+298	establishment	9.0	marketing processing	3.0	testfoni	1.0	represent	1.0	marketing processing	3.0	testfoni	1.0	endeavor	1.0	marketing processing	3.0	telegram	1.0	endeavor	1.0	override	5	destruction	2.0	program	1.0	disagree	1.0	password	3.0	support centre	1.0	inquire	1.0	identifier	2.0	chief	1.0	customize	1.0
+299	compliance	9.0	update information	3.0	nhn	1.0	edit hide	1.0	update information	3.0	nhn	1.0	collect process	1.0	update information	3.0	testfoni	1.0	collect process	1.0	condition	5	summary	2.0	location	1.0	inquire	1.0	help center	3.0	data protection team	1.0	come	1.0	ad	2.0	instagram	1.0	outline	1.0
+300	allow	9.0	support	3.0	information commissioners	1.0	endeavor	1.0	support	3.0	information commissioners	1.0	escalate	1.0	support	3.0	nhn	1.0	escalate	1.0	regard	5	promotion	2.0	access	1.0	come	1.0	operation	3.0	fireproof studios ltd	1.0	authorize	1.0	nickname	2.0	netmarble	1.0	remind	1.0
+301	provision	9.0	interest right	3.0	nicosia cyprus	1.0	collect process	1.0	interest right	3.0	nicosia cyprus	1.0	turn	1.0	interest right	3.0	nicosia cyprus	1.0	turn	1.0	alternative	5	ad	2.0	pnix	1.0	retrieve	1.0	privacy matter	3.0	pepper deals ltd	1.0	hear	1.0	restrict	2.0	yazio	1.0	substantiate	1.0
+302	disable	8.0	approach	3.0	boubolina	1.0	escalate	1.0	approach	3.0	boubolina	1.0	place delete	1.0	approach	3.0	information commissioners	1.0	place delete	1.0	support team	5	identifier	2.0	bluehole	1.0	authorize	1.0	privacy notice	3.0	batemans row london ec2a	1.0	stop collect	1.0	software	2.0	local	1.0	guarantee	1.0
+303	automate	8.0	personal information	3.0	sunnyvale	1.0	turn	1.0	personal information	3.0	sunnyvale	1.0	include disassociate	1.0	personal information	3.0	boubolina	1.0	include disassociate	1.0	information rectify	5	nickname	2.0	canada	1.0	-emailuse	1.0	keyword	2.0	ico wycliffe house water lane wilmslow	1.0	consult	1.0	building	2.0	banking	1.0	preserve	1.0
+304	notify	8.0	registration number	3.0	california privacy rights	1.0	place delete	1.0	registration number	3.0	california privacy rights	1.0	lose	1.0	registration number	3.0	sunnyvale	1.0	lose	1.0	datum hold	5	restrict	2.0	costa	1.0	consult	1.0	pre	2.0	cheshire	1.0	forward	1.0	tracking	2.0	bank	1.0	disclaim	1.0
+305	carry	8.0	support e	3.0	privacy tubi inc	1.0	include disassociate	1.0	support e	3.0	privacy tubi inc	1.0	block delete	1.0	support e	3.0	california privacy rights	1.0	block delete	1.0	correct update	5	software	2.0	rica	1.0	forward	1.0	hinderance	2.0	tgtg	1.0	customize	1.0	transformation	2.0	imo	1.0	love	1.0
+306	previously	8.0	regulator	3.0	montgomery street	1.0	lose	1.0	regulator	3.0	montgomery street	1.0	employ	1.0	regulator	3.0	privacy tubi inc	1.0	employ	1.0	restrict use	5	tracking	2.0	discord	1.0	customize	1.0	advertisement	2.0	facebook	1.0	process contact	1.0	opportunity	2.0	s	1.0	adhere	1.0
+307	feature	8.0	provider	3.0	twitter inc	1.0	block delete	1.0	provider	3.0	twitter inc	1.0	object apply	1.0	provider	3.0	montgomery street	1.0	object apply	1.0	profile setting	5	transformation	2.0	h.k	1.0	outline	1.0	contact datum	2.0	google	1.0	outline	1.0	task	2.0	security	1.0	proceed	1.0
+308	national	8.0	privacy law	3.0	jams	1.0	employ	1.0	privacy law	3.0	jams	1.0	correct complete	1.0	privacy law	3.0	twitter inc	1.0	correct complete	1.0	think	5	opportunity	2.0	chai	1.0	remind	1.0	appeal	2.0	lindgreens	1.0	guarantee	1.0	proof	2.0	keeper	1.0	track	1.0
+309	forget	8.0	password	3.0	-emailwith	1.0	object apply	1.0	password	3.0	-emailwith	1.0	achieve	1.0	password	3.0	jams	1.0	achieve	1.0	follow apply	5	task	2.0	rm	1.0	substantiate	1.0	version	2.0	k?benhavn sor	1.0	substantiate	1.0	registry	2.0	entertainment	1.0	empower	1.0
+310	infringe	8.0	help center	3.0	adobe	1.0	correct complete	1.0	help center	3.0	adobe	1.0	determine	1.0	help center	3.0	-emailwith	1.0	determine	1.0	complete	5	proof	2.0	lockhart	1.0	guarantee	1.0	privacy email	2.0	restaurants limited customer services	1.0	act accord	1.0	location	2.0	ape	1.0	gain	1.0
+311	respective	8.0	operation	3.0	site applications	1.0	achieve	1.0	operation	3.0	site applications	1.0	undertake	1.0	operation	3.0	adobe	1.0	undertake	1.0	dispute	5	registry	2.0	ro	1.0	requests	1.0	contact service page	2.0	high road east finchley london	1.0	access read preserve	1.0	tab	2.0	thinking	1.0	treat	1.0
+312	floor	8.0	privacy matter	3.0	neptune	1.0	determine	1.0	privacy matter	3.0	neptune	1.0	quote	1.0	privacy matter	3.0	site applications	1.0	quote	1.0	decide	5	location	2.0	wan	1.0	reque	1.0	research	2.0	mcdonald	1.0	vary base	1.0	sns	2.0	labs	1.0	browse	1.0
+313	display	8.0	privacy notice	3.0	google play /apple app store	1.0	undertake	1.0	privacy notice	3.0	google play /apple app store	1.0	s	1.0	privacy notice	3.0	neptune	1.0	s	1.0	switzerland	5	tab	2.0	clicktouch	1.0	disclaim	1.0	owner contact email	2.0	uk information commissioners office	1.0	disclaim	1.0	future	2.0	planb	1.0	tap	1.0
+314	kingdom	8.0	keyword	2.0	ellation inc.	1.0	quote	1.0	keyword	2.0	ellation inc.	1.0	remember	1.0	keyword	2.0	google play /apple app store	1.0	remember	1.0	legislator	5	sns	2.0	ab	1.0	love	1.0	retention period	2.0	legal department freeview	1.0	adhere	1.0	representative	2.0	park	1.0	scroll	1.0
+315	choice	8.0	pre	2.0	market st	1.0	remember	1.0	pre	2.0	market st	1.0	select remove	1.0	pre	2.0	ellation inc.	1.0	select remove	1.0	grant	5	future	2.0	dvapps	1.0	adhere	1.0	aspect	2.0	floor	1.0	review update	1.0	ticket	2.0	homer	1.0	bring	1.0
+316	writing	8.0	hinderance	2.0	cube software	1.0	select remove	1.0	hinderance	2.0	cube software	1.0	automate process include	1.0	hinderance	2.0	market st	1.0	automate process include	1.0	existence	5	representative	2.0	dvloper	1.0	proceed	1.0	exception	2.0	dtv services ltd	1.0	help solve	1.0	word	2.0	letsvpn	1.0	volunteer	1.0
+317	ve	8.0	advertisement	2.0	rue pierre picard	1.0	automate process include	1.0	advertisement	2.0	dashlane sas	1.0	define	1.0	advertisement	2.0	cube software	1.0	define	1.0	statement	5	port	2.0	limassol	1.0	track	1.0	membership	2.0	digital uk limited	1.0	track	1.0	clarification	2.0	level	1.0	deny	1.0
+318	detailed	8.0	contact datum	2.0	dashlane sas	1.0	define	1.0	contact datum	2.0	rue pierre picard	1.0	outweigh	1.0	contact datum	2.0	dashlane sas	1.0	outweigh	1.0	ensure	5	ticket	2.0	easybrain	1.0	empower	1.0	duration	2.0	data protection act	1.0	object restrict	1.0	substance	2.0	sky	1.0	present	1.0
+319	llc	8.0	appeal	2.0	supervisory	1.0	outweigh	1.0	appeal	2.0	supervisory	1.0	include base	1.0	appeal	2.0	rue pierre picard	1.0	include base	1.0	conduct	5	word	2.0	krinou	1.0	gain	1.0	feature	2.0	picsart inc.	1.0	empower	1.0	realization	2.0	lima	1.0	precede	1.0
+320	minimum	8.0	privacy email	2.0	longyuan network	1.0	include base	1.0	privacy email	2.0	longyuan network	1.0	abide	1.0	privacy email	2.0	supervisory	1.0	abide	1.0	enquiry	5	clarification	2.0	oval	1.0	treat	1.0	access request	2.0	california business	1.0	gain	1.0	accident	2.0	lion??s	1.0	exchange	1.0
+321	furthermore	8.0	contact service page	2.0	advertising id	1.0	abide	1.0	contact service page	2.0	advertising id	1.0	redirect	1.0	contact service page	2.0	longyuan network	1.0	redirect	1.0	response	5	substance	2.0	technopark	1.0	browse	1.0	member state	2.0	sutter st.	1.0	treat	1.0	topic	2.0	belgium	1.0	stipulate	1.0
+322	record	8.0	research	2.0	google android	1.0	redirect	1.0	research	2.0	apple ios	1.0	renew correct	1.0	research	2.0	advertising id	1.0	renew correct	1.0	indicate	5	realization	2.0	perm	1.0	tap	1.0	scope	2.0	professions code section	1.0	solve	1.0	limit	2.0	westrem	1.0	discuss	1.0
+323	urlor	8.0	owner contact email	2.0	apple ios	1.0	renew correct	1.0	owner contact email	2.0	google android	1.0	justify	1.0	owner contact email	2.0	apple ios	1.0	justify	1.0	attn	5	topic	2.0	stakhanovskaya	1.0	scroll	1.0	visitor	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0	browse	1.0	opposition	2.0	denijs	1.0	express	1.0
+324	uber	8.0	retention period	2.0	california civil code section	1.0	justify	1.0	retention period	2.0	california civil code section	1.0	reserve	1.0	retention period	2.0	google android	1.0	reserve	1.0	request regard	5	accident	2.0	findnow	1.0	volunteer	1.0	unsubscribe link	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0	search	1.0	amendment	2.0	sint	1.0	exist	1.0
+325	removal	7.0	aspect	2.0	-urlfor	1.0	reserve	1.0	aspect	2.0	-urlfor	1.0	realise	1.0	aspect	2.0	california civil code section	1.0	realise	1.0	event	5	limit	2.0	strovolos	1.0	deny	1.0	datum privacy	2.0	services uk europe	1.0	tap	1.0	button	2.0	soudanstraat	1.0	port	1.0
+326	oppose	7.0	exception	2.0	bbb eu privacy shield	1.0	realise	1.0	exception	2.0	bbb eu privacy shield	1.0	gather edit add	1.0	exception	2.0	-urlfor	1.0	gather edit add	1.0	communication	5	opposition	2.0	petousis	1.0	present	1.0	cost	2.0	international dpd	1.0	scroll	1.0	discretion	2.0	octaaf	1.0	put	1.0
+327	undergo	7.0	membership	2.0	facebook google	1.0	gather edit add	1.0	membership	2.0	facebook google	1.0	recover	1.0	membership	2.0	bbb eu privacy shield	1.0	recover	1.0	privacy notice	5	amendment	2.0	sevilla	1.0	precede	1.0	privacy issue	2.0	dpd terms	1.0	say	1.0	family	2.0	amino	1.0	here	1.0
+328	good	7.0	duration	2.0	stockholm sweden	1.0	recover	1.0	duration	2.0	brunnsgatan	1.0	review correct	1.0	duration	2.0	facebook google	1.0	review correct	1.0	request portability	5	button	2.0	spain	1.0	exchange	1.0	activity	2.0	brexit csr press centre	1.0	hope	1.0	thing	2.0	art.18	1.0	corrector	1.0
+329	union	7.0	feature	2.0	brunnsgatan	1.0	review correct	1.0	feature	2.0	stockholm sweden	1.0	plan	1.0	feature	2.0	brunnsgatan	1.0	plan	1.0	access edit	5	discretion	2.0	genera	1.0	stipulate	1.0	browser add	2.0	update	1.0	bring	1.0	connection	2.0	geims	1.0	lead	1.0
+330	notification	7.0	member state	2.0	gamegos	1.0	plan	1.0	member state	2.0	gamegos	1.0	disagree	1.0	member state	2.0	stockholm sweden	1.0	disagree	1.0	confirm	5	family	2.0	s.l	1.0	discuss	1.0	association	2.0	conditions	1.0	deny	1.0	origin	2.0	nova	1.0	reflect	1.0
+331	id	7.0	scope	2.0	gametion technologies pvt ltd	1.0	disagree	1.0	scope	2.0	gametion technologies pvt ltd	1.0	inquire	1.0	scope	2.0	gamegos	1.0	inquire	1.0	datum undergo processing	5	thing	2.0	cardenal	1.0	express	1.0	request form	2.0	commitment	1.0	present	1.0	balance	2.0	supervisor	1.0	envisage	1.0
+332	product	7.0	visitor	2.0	eu representative	1.0	inquire	1.0	visitor	2.0	eu representative	1.0	come	1.0	visitor	2.0	gametion technologies pvt ltd	1.0	come	1.0	protect	5	connection	2.0	bueno	1.0	port	1.0	party information collection	2.0	apec cbpr	1.0	update amend	1.0	client	2.0	outfit7	1.0	-emailmake	1.0
+333	export	7.0	testimonial	2.0	liverpool street london ec2 m	1.0	come	1.0	testimonial	2.0	liverpool street london ec2 m	1.0	retrieve	1.0	testimonial	2.0	eu representative	1.0	retrieve	1.0	eu member state	5	origin	2.0	monreal	1.0	put	1.0	advertising id	2.0	privacyto	1.0	precede	1.0	history	2.0	informationsfreiheit	1.0	hit	1.0
+334	accurate	7.0	unsubscribe link	2.0	dpo centre	1.0	retrieve	1.0	unsubscribe link	2.0	dpo centre	1.0	authorize	1.0	unsubscribe link	2.0	liverpool street london ec2 m	1.0	authorize	1.0	-email-	5	balance	2.0	planta	1.0	here	1.0	summary	2.0	apple	1.0	correct amend	1.0	chat	2.0	datenschutz	1.0	esc	1.0
+335	reside	7.0	datum privacy	2.0	gogogame	1.0	authorize	1.0	datum privacy	2.0	gogogame	1.0	hear	1.0	datum privacy	2.0	dpo centre	1.0	hear	1.0	information delete	5	client	2.0	geozilla	1.0	corrector	1.0	change update	2.0	european data protection officer	1.0	exchange	1.0	download	2.0	beauftragte	1.0	recommend	1.0
+336	pursuant	7.0	process	2.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0	hear	1.0	process	2.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0	-emailuse	1.0	process	2.0	gogogame	1.0	-emailuse	1.0	data processing	5	chat	2.0	chief	1.0	lead	1.0	entity	2.0	apples privacy policy	1.0	stipulate	1.0	telemarketing	2.0	berliner	1.0	2019welcome	1.0
+337	alternatively	7.0	privacy issue	2.0	java	1.0	-emailuse	1.0	privacy issue	2.0	java	1.0	stop collect	1.0	privacy issue	2.0	data protection good catch ltd shepherds building central charecroft way shepherds bush london w14	1.0	stop collect	1.0	information change	5	history	2.0	healthvault	1.0	reflect	1.0	administrator	2.0	prp	1.0	lift	1.0	studio	2.0	ii.i.1.d	1.0	authorise	1.0
+338	phone	7.0	browser add	2.0	rijk	1.0	stop collect	1.0	browser add	2.0	schiphol	1.0	consult	1.0	activity	2.0	java	1.0	consult	1.0	desire	5	download	2.0	instagram	1.0	envisage	1.0	customer support	2.0	calabasas rd calabasas	1.0	express	1.0	satisfaction	2.0	kong	1.0	demonstrate	1.0
+339	states	7.0	activity	2.0	schiphol	1.0	consult	1.0	activity	2.0	rijk	1.0	forward	1.0	browser add	2.0	beechavenue	1.0	forward	1.0	service provider	5	telemarketing	2.0	netmarble	1.0	-emailmake	1.0	legislation	2.0	contact	1.0	complain	1.0	-urlfor	2.0	hong	1.0	examine	1.0
+340	block	7.0	account tool	2.0	beechavenue	1.0	forward	1.0	account tool	2.0	beechavenue	1.0	customize	1.0	account tool	2.0	schiphol	1.0	customize	1.0	identity	5	studio	2.0	yazio	1.0	hit	1.0	transformation	2.0	planetart llc	1.0	exist	1.0	acknowledgment	2.0	israel	1.0	balance	1.0
+341	contain	7.0	association	2.0	grab	1.0	customize	1.0	association	2.0	grab	1.0	process contact	1.0	association	2.0	rijk	1.0	process contact	1.0	marketing communication	5	acknowledgment	2.0	local	1.0	esc	1.0	opportunity	2.0	account settings	1.0	port	1.0	mind	2.0	zone	1.0	reference	1.0
+342	supplement	7.0	request form	2.0	data privacy officer	1.0	process contact	1.0	request form	2.0	data privacy officer	1.0	outline	1.0	request form	2.0	grab	1.0	outline	1.0	question regard privacy	5	satisfaction	2.0	banking	1.0	recommend	1.0	unsubscribe instruction	2.0	notification settings	1.0	corrector update	1.0	passport	2.0	industrial	1.0	improve	1.0
+343	year	7.0	party information collection	2.0	applicationsor	1.0	outline	1.0	party information collection	2.0	applicationsor	1.0	remind	1.0	party information collection	2.0	data privacy officer	1.0	remind	1.0	click	5	-urlfor	2.0	bank	1.0	2019welcome	1.0	task	2.0	center	1.0	reflect	1.0	misuse	2.0	ayin	1.0	interact	1.0
+344	confirmation	7.0	advertising id	2.0	office ofdata protection	1.0	remind	1.0	advertising id	2.0	office ofdata protection	1.0	guarantee	1.0	advertising id	2.0	applicationsor	1.0	guarantee	1.0	affect	5	mind	2.0	s	1.0	authorise	1.0	question comment complaint	2.0	datainspektionen	1.0	access restrict	1.0	payment	2.0	ha	1.0	invite	1.0
+345	aware	7.0	summary	2.0	huuuges	1.0	substantiate	1.0	summary	2.0	huuuges	1.0	substantiate	1.0	summary	2.0	huuuges	1.0	substantiate	1.0	information commissioner	5	review	2.0	keeper	1.0	demonstrate	1.0	sns	2.0	w 18th street	1.0	welcome	1.0	property	2.0	rosh	1.0	import	1.0
+346	contest	7.0	change update	2.0	president	1.0	guarantee	1.0	change update	2.0	president	1.0	act accord	1.0	change update	2.0	office ofdata protection	1.0	act accord	1.0	review update	5	passport	2.0	security	1.0	examine	1.0	future	2.0	new york ny	1.0	envisage	1.0	license	2.0	str	1.0	elect	1.0
+347	attn	7.0	customer support	2.0	huuugegroup	1.0	act accord	1.0	customer support	2.0	huuugegroup	1.0	requests	1.0	customer support	2.0	president	1.0	requests	1.0	stop	5	misuse	2.0	entertainment	1.0	balance	1.0	business interest	2.0			instal	1.0	test	2.0	internatsionalnaya	1.0	switch	1.0
+348	performance	7.0	legislation	2.0	huuuge games sp	1.0	requests	1.0	legislation	2.0	huuuge games sp	1.0	reque	1.0	legislation	2.0	huuuge	1.0	reque	1.0	uber	5	property	2.0	thinking	1.0	reference	1.0	game account datum	2.0			-emailmake	1.0	assessment	2.0	masha	1.0	lease	1.0
+349	jurisdiction	7.0	building	2.0	huuuges dpo	1.0	reque	1.0	building	2.0	huuuges dpo	1.0	access read preserve	1.0	building	2.0	huuugegroup	1.0	access read preserve	1.0	privacy center	5	license	2.0	ape	1.0	improve	1.0	word	2.0			act	1.0	evaluation	2.0	republic	1.0	distribute	1.0
+350	balancing	7.0	s	2.0	mopub	1.0	access read preserve	1.0	s	2.0	mopub	1.0	vary base	1.0	transformation	2.0	huuuge games sp	1.0	vary base	1.0	paragraph	4	evaluation	2.0	labs	1.0	talk	1.0	clarification	2.0			search hit enter	1.0	measure	2.0	swag	1.0	look	1.0
+351	protect	7.0	transformation	2.0	data protection officerone cumberland place fenian streetdublin	1.0	vary base	1.0	transformation	2.0	data protection officerone cumberland place fenian streetdublin	1.0	disclaim	1.0	unsubscribe instruction	2.0	huuuges dpo	1.0	disclaim	1.0	privacy question	4	assessment	2.0	planb	1.0	interact	1.0	substance	2.0			esc	1.0	problem	2.0	liability	1.0	fill	1.0
+352	compelling	7.0	unsubscribe instruction	2.0	market street suite 900san francisco	1.0	disclaim	1.0	unsubscribe instruction	2.0	market street suite 900san francisco	1.0	love hear	1.0	opportunity	2.0	mopub	1.0	love hear	1.0	access request	4	test	2.0	park	1.0	invite	1.0	realization	2.0			recommend	1.0	box	2.0	ga	1.0	advise	1.0
+353	regulator	7.0	opportunity	2.0	twitter inc.	1.0	love hear	1.0	opportunity	2.0	twitter inc.	1.0	adhere	1.0	task	2.0	data protection officerone cumberland place fenian streetdublin	1.0	adhere	1.0	para	4	measure	2.0	letsvpn	1.0	import	1.0	datum breach	2.0			2019welcome	1.0	attention	2.0	woodstock	1.0	misuse	1.0
+354	cease	7.0	task	2.0	ireland	1.0	adhere	1.0	task	2.0	ireland	1.0	proceed	1.0	question comment complaint	2.0	market street suite 900san francisco	1.0	proceed	1.0	enter	4	box	2.0	level	1.0	elect	1.0	topic	2.0			authorise	1.0	means	2.0	ave	1.0	buy	1.0
+355	letter	6.0	question comment complaint	2.0	twitter international companys	1.0	proceed	1.0	question comment complaint	2.0	twitter international companys	1.0	review update	1.0	proof	2.0	twitter inc.	1.0	review update	1.0	requirement	4	attention	2.0	lima	1.0	switch	1.0	accident	2.0			demonstrate	1.0	adherence	2.0	aurora	1.0	acquire	1.0
+356	paragraph	6.0	proof	2.0	mark lane london	1.0	review update	1.0	proof	2.0	tricor	1.0	track	1.0	agent	2.0	ireland	1.0	track	1.0	nature	4	book	2.0	sky	1.0	look	1.0	assistance	2.0			examine	1.0	variation	2.0	tastypill	1.0	deliver	1.0
+357	prejudice	6.0	agent	2.0	tricor	1.0	help solve	1.0	agent	2.0	mark lane london	1.0	help solve	1.0	sns	2.0	twitter international companys	1.0	help solve	1.0	breach	4	means	2.0	lion??s	1.0	distribute	1.0	subject	2.0			balance	1.0	portion	2.0	testfoni	1.0	return	1.0
+358	handle	6.0	sns	2.0	saygames llc	1.0	track	1.0	sns	2.0	saygames llc	1.0	object restrict	1.0	future	2.0	tricor	1.0	object restrict	1.0	datum delete object	4	adherence	2.0	denijs	1.0	lease	1.0	controller confirmation	2.0			reference	1.0	calendar	2.0	nhn	1.0	familiarize	1.0
+359	current	6.0	future	2.0	platonova	1.0	object restrict	1.0	future	2.0	platonova	1.0	empower	1.0	representative	2.0	mark lane london	1.0	empower	1.0	request correction	4	variation	2.0	sint	1.0	misuse	1.0	making	2.0			improve	1.0	transmission	2.0	boubolina	1.0	jeopardize	1.0
+360	decision	6.0	representative	2.0	cookie	1.0	empower	1.0	representative	2.0	cookie	1.0	gain	1.0	business interest	2.0	saygames llc	1.0	gain	1.0	provide service	4	action	2.0	westrem	1.0	advise	1.0	state authority	2.0			supply	1.0	society	2.0	topface	1.0	triage	1.0
+361	owner	6.0	business interest	2.0	cookie policy	1.0	gain	1.0	business interest	2.0	cookie policy	1.0	treat	1.0	game account datum	2.0	platonova	1.0	treat	1.0	resident	4	portion	2.0	octaaf	1.0	buy	1.0	rectification deletion	2.0			correct erase restrict	1.0	publisher	2.0	sunnyvale	1.0	anonymise	1.0
+362	important	6.0	game account datum	2.0	addressable platform limited	1.0	treat	1.0	game account datum	2.0	addressable platform limited	1.0	solve	1.0	word	2.0	cookie	1.0	solve	1.0	-emailwith	4	calendar	2.0	soudanstraat	1.0	acquire	1.0	decision making	2.0			interact	1.0	agent	2.0	montgomery	1.0	enjoy	1.0
+363	17	6.0	word	2.0	britbox	1.0	solve	1.0	word	2.0	britbox	1.0	browse	1.0	clarification	2.0	cookie policy	1.0	browse	1.0	fee	4	transmission	2.0	belgium	1.0	deliver	1.0	opposition	2.0			remain	1.0	vat	2.0	tubi	1.0	authenticate	1.0
+364	effort	6.0	clarification	2.0	stephen street london w1 t	1.0	browse	1.0	clarification	2.0	stephen street london w1 t	1.0	search	1.0	substance	2.0	addressable platform limited	1.0	search	1.0	verification	4	society	2.0	art.18	1.0	return	1.0	button	2.0			import	1.0	range	2.0	periscope	1.0	rate	1.0
+365	lawful	6.0	substance	2.0	holborn london ec1n	1.0	scroll	1.0	substance	2.0	holborn london ec1n	1.0	scroll	1.0	realization	2.0	britbox	1.0	tap	1.0	residence place	4	publisher	2.0	nova	1.0	familiarize	1.0	app support feature	2.0			invite	1.0	seller	2.0	principles	1.0		
+366	think	6.0	realization	2.0	itv rights limited	1.0	search	1.0	realization	2.0	itv rights limited	1.0	tap	1.0	datum breach	2.0	got talent	1.0	scroll	1.0	sign	4	vat	2.0	geims	1.0	jeopardize	1.0	login	2.0			elect	1.0	citizen	2.0	jams	1.0		
+367	emailif	6.0	datum breach	2.0	itv consumer limited	1.0	tap	1.0	datum breach	2.0	itv consumer limited	1.0	volunteer	1.0	topic	2.0	itv rights limited	1.0	volunteer	1.0	datum use concern	4	range	2.0	supervisor	1.0	triage	1.0	discretion	2.0			switch	1.0	national	2.0	applications	1.0		
+368	residence	6.0	accident	2.0	fremantle media limited	1.0	volunteer	1.0	topic	2.0	fremantle media limited	1.0	deny	1.0	accident	2.0	itv consumer limited	1.0	deny	1.0	phone	4	seller	2.0	outfit7	1.0	anonymise	1.0	data protection regulator	2.0			fill	1.0	position	1.0	site	1.0		
+369	hesitate	6.0	topic	2.0	got talent	1.0	deny	1.0	accident	2.0	waterhouse square	1.0	present	1.0	subject	2.0	holborn london ec1n	1.0	present	1.0	de-identify	4	national	2.0	informationsfreiheit	1.0	enjoy	1.0	privacy officer	2.0			look	1.0	b	1.0	neptune	1.0		
+370	feedback	6.0	subject	2.0	waterhouse square	1.0	present	1.0	subject	2.0	got talent	1.0	update amend	1.0	controller confirmation	2.0	stephen street london w1 t	1.0	update amend	1.0	day	4	citizen	2.0	berlin	1.0	authenticate	1.0	consent contract	2.0			sell distribute	1.0	boulevard	1.0	store	1.0		
+371	identify	6.0	controller confirmation	2.0	x factor	1.0	update amend	1.0	controller confirmation	2.0	x factor	1.0	precede	1.0	making	2.0	x factor	1.0	precede	1.0	registration	4	position	1.0	berliner	1.0	rate	1.0	thing	2.0			lease	1.0	expiration	1.0	/apple	1.0		
+372	specify	6.0	making	2.0	britain	1.0	precede	1.0	making	2.0	britain	1.0	correct amend	1.0	state authority	2.0	fremantle media limited	1.0	correct amend	1.0	datum subject	4	b	1.0	beauftragte	1.0			connection	2.0			update edit	1.0	justification	1.0	play	1.0		
+373	storage	6.0	state authority	2.0	gb	1.0	correct amend	1.0	state authority	2.0	gb	1.0	exchange	1.0	rectification deletion	2.0	britain	1.0	exchange	1.0	procedure	4	boulevard	1.0	datenschutz	1.0			menu	2.0			misuse	1.0	scenario	1.0	ellation	1.0		
+374	digital	6.0	rectification deletion	2.0	hydrane sas	1.0	exchange	1.0	rectification deletion	2.0	hydrane sas	1.0	stipulate	1.0	decision making	2.0	waterhouse square	1.0	stipulate	1.0	handling	4	expiration	1.0	kwalee	1.0			origin	2.0			advise	1.0	termination	1.0	software	1.0		
+375	method	6.0	decision making	2.0	denis	1.0	stipulate	1.0	decision making	2.0	denis	1.0	discuss	1.0	opposition	2.0	gb	1.0	discuss	1.0	error	4	justification	1.0	ii.i.1.d	1.0			user information	2.0			acquire	1.0	behaviour	1.0	cube	1.0		
+376	outdated	6.0	opposition	2.0	paris	1.0	discuss	1.0	opposition	2.0	paris	1.0	express	1.0	button	2.0	hydrane sas	1.0	express	1.0	profile page	4	scenario	1.0	hong	1.0			customer service channel	2.0			sell	1.0	obstruction	1.0	picard	1.0		
+377	agree	6.0	button	2.0	companyabout games blog jobs	1.0	express	1.0	button	2.0	companyabout games blog jobs	1.0	port	1.0	app support feature	2.0	paris	1.0	port	1.0	update block	4	behaviour	1.0	kong	1.0			client	2.0			buy	1.0	transferability	1.0	pierre	1.0		
+378	conduct	6.0	app support feature	2.0	denis paris france	1.0	port	1.0	app support feature	2.0	denis paris france	1.0	put	1.0	login	2.0	denis	1.0	put	1.0	service support	4	termination	1.0	rosh	1.0			marketing analytic	2.0			deliver	1.0	current	1.0	dashlane	1.0		
+379	unhappy	6.0	login	2.0	twitter facebook linkedin	1.0	put	1.0	login	2.0	games articles	1.0	here	1.0	discretion	2.0	denis paris france	1.0	here	1.0	netherlands	4	transferability	1.0	ha	1.0			chat history	2.0			return	1.0	users	1.0	network	1.0		
+380	enquiry	6.0	discretion	2.0	games articles	1.0	here	1.0	discretion	2.0	twitter facebook linkedin	1.0	corrector update	1.0	data protection regulator	2.0	companyabout games blog jobs	1.0	corrector update	1.0	e-mail address	4	obstruction	1.0	industrial	1.0			telemarketing	2.0			jeopardize	1.0	widget	1.0	longyuan	1.0		
+381	mailing	6.0	data protection regulator	2.0	events careers	1.0	corrector update	1.0	data protection regulator	2.0	events careers	1.0	lead	1.0	consent contract	2.0	games articles	1.0	lead	1.0	investigate	4	exit	1.0	zone	1.0			datum protection authority	2.0			triage	1.0	expression	1.0	android	1.0		
+382	administrator	6.0	consent contract	2.0	rue	1.0	lead	1.0	consent contract	2.0	rue	1.0	reflect	1.0	thing	2.0	rue	1.0	reflect	1.0	help	4	current	1.0	israel	1.0			interest rule	2.0			assert	1.0	evidence	1.0	ios	1.0		
+383	promotional	6.0	thing	2.0	.california	1.0	reflect	1.0	thing	2.0	.california	1.0	access restrict	1.0	connection	2.0	twitter facebook linkedin	1.0	access restrict	1.0	entitled	4	users	1.0	ayin	1.0			studio	2.0			anonymise	1.0	ight	1.0	duolingo	1.0		
+384	report	6.0	connection	2.0	tiktok inc	1.0	access restrict	1.0	connection	2.0	tiktok inc	1.0	envisage	1.0	menu	2.0	events careers	1.0	envisage	1.0	line	4	widget	1.0	diandian	1.0			acknowledgment	2.0			authenticate	1.0	authoriy	1.0	bbb	1.0		
+385	individual	6.0	menu	2.0	tiktok legal department	1.0	envisage	1.0	menu	2.0	venice blvd suite	1.0	-emailmake	1.0	origin	2.0	.california	1.0	-emailmake	1.0	information collect	4	expression	1.0	str	1.0			satisfaction	2.0			vary	1.0	call	1.0	flaregames	1.0		
+386	facebook	6.0	origin	2.0	venice blvd suite	1.0	-emailmake	1.0	origin	2.0	tiktok legal department	1.0	search hit enter	1.0	user information	2.0	tiktok inc	1.0	search hit enter	1.0	privacy policy administrator	4	evidence	1.0	republic	1.0			-urlfor	2.0			rate	1.0	pay	1.0	sweden	1.0		
+387	matter	6.0	user information	2.0	culver city	1.0	search hit enter	1.0	user information	2.0	culver city	1.0	esc	1.0	customer service channel	2.0	venice blvd suite	1.0	esc	1.0	request information	4	ight	1.0	internatsionalnaya	1.0			mind	2.0					principle	1.0	stockholm	1.0		
+388	mention	6.0	customer service channel	2.0	usaemail	1.0	esc	1.0	customer service channel	2.0	usaemail	1.0	recommend	1.0	client	2.0	tiktok legal department	1.0	recommend	1.0	stop process	4	authoriy	1.0	liability	1.0			passport	2.0					com	1.0	brunnsgatan	1.0		
+389	description	6.0	client	2.0	october	1.0	recommend	1.0	client	2.0	october	1.0	2019welcome	1.0	marketing analytic	2.0	culver city	1.0	2019welcome	1.0	adjust	4	pay	1.0	swag	1.0			misuse	2.0					dot	1.0	pvt	1.0		
+390	ability	6.0	marketing analytic	2.0	bytedance uk limited aviation house	1.0	2019welcome	1.0	marketing analytic	2.0	bytedance uk limited aviation house	1.0	demonstrate	1.0	chat history	2.0	usaemail	1.0	authorise	1.0	performance	4	principle	1.0	masha	1.0			driver	2.0					mondly	1.0	gametion	1.0		
+391	refuse	6.0	chat history	2.0	kingsway holborn london wc2b	1.0	demonstrate	1.0	chat history	2.0	kingsway holborn london wc2b	1.0	authorise	1.0	telemarketing	2.0	october	1.0	demonstrate	1.0	abuse	4	com	1.0	ga	1.0			payment information	2.0					opt	1.0	m	1.0		
+392	ii	6.0	telemarketing	2.0	summarywhat	1.0	authorise	1.0	telemarketing	2.0	summarywhat	1.0	balance	1.0	datum protection authority	2.0	bytedance uk limited aviation house	1.0	examine	1.0	body	4	mondly	1.0	aurora	1.0			request question	2.0					stock	1.0	ec2	1.0		
+393	commissioner	6.0	datum protection authority	2.0	contractual	1.0	balance	1.0	interest rule	2.0	contractual	1.0	examine	1.0	interest rule	2.0	kingsway holborn london wc2b	1.0	balance	1.0	step	4	dot	1.0	ave	1.0			user license	2.0					indication	1.0	liverpool	1.0		
+394	try	6.0	interest rule	2.0	ironhide	1.0	examine	1.0	studio	2.0	ironhide	1.0	reference	1.0	studio	2.0	summarywhat	1.0	reference	1.0	matter	4	opt	1.0	woodstock	1.0			balancing test	2.0					declaration	1.0	gogogame	1.0		
+395	generally	6.0	studio	2.0	flash	1.0	reference	1.0	satisfaction	2.0	flash	1.0	improve	1.0	acknowledgment	2.0	contractual	1.0	improve	1.0	access information hold	4	stock	1.0	tastypill	1.0			evaluation	2.0					following	1.0	shepherds	1.0		
+396	registered	6.0	acknowledgment	2.0	product availability alerts delivers	1.0	improve	1.0	-urlfor	2.0	product availability alerts delivers	1.0	talk	1.0	satisfaction	2.0	ironhide	1.0	talk	1.0	llc	4	indication	1.0	telegram	1.0			assessment	2.0					possibility	1.0	w14	1.0		
+397	doubleugames	6.0	-urlfor	2.0	recommendations listmania	1.0	talk	1.0	acknowledgment	2.0	recommendations listmania	1.0	correct erase restrict	1.0	-urlfor	2.0	flash	1.0	correct erase restrict	1.0	webmartgroup	4	declaration	1.0	testfoni	1.0			deactivation page	2.0					recovery	1.0	charecroft	1.0		
+398	duolingo	6.0	satisfaction	2.0	wish list	1.0	correct erase restrict	1.0	mind	2.0	wish list	1.0	interact	1.0	mind	2.0	product availability alerts delivers	1.0	interact	1.0	rule	4	following	1.0	nhn	1.0			feedback page	2.0					manager	1.0	way	1.0		
+399	platform	6.0	mind	2.0	recommended	1.0	interact	1.0	passport	2.0	recommended	1.0	import	1.0	passport	2.0	recommendations listmania	1.0	import	1.0	datum erase	4	possibility	1.0	boubolina	1.0			problem	2.0					power	1.0	central	1.0		
+400	meet	5.0	passport	2.0	lists	1.0	invite	1.0	misuse	2.0	lists	1.0	invite	1.0	misuse	2.0	recommended	1.0	invite	1.0	problem	4	recovery	1.0	sunnyvale	1.0			support	2.0					conduct	1.0	building	1.0		
+401	77	5.0	misuse	2.0	wedding	1.0	import	1.0	driver	2.0	baby	1.0	elect	1.0	driver	2.0	lists	1.0	elect	1.0	category	4	manager	1.0	tubi	1.0			attention	2.0					estriction	1.0	catch	1.0		
+402	type	5.0	driver	2.0	baby	1.0	elect	1.0	payment information	2.0	wedding	1.0	switch	1.0	payment information	2.0	baby	1.0	switch	1.0	period	4	power	1.0	montgomery	1.0			address book contact	2.0					contradiction	1.0	good	1.0		
+403	retention	5.0	payment information	2.0	floor millmead guildford surrey england gu2 4hj	1.0	switch	1.0	request question	2.0	floor millmead guildford surrey england gu2 4hj	1.0	sell distribute	1.0	request question	2.0	wedding	1.0	sell distribute	1.0	access rectify	4	conduct	1.0	jams	1.0			means	2.0					behalf	1.0	rijk	1.0		
+404	appoint	5.0	request question	2.0	hays house north wing	1.0	sell distribute	1.0	user license	2.0	hays house north wing	1.0	look	1.0	user license	2.0	wish list	1.0	look	1.0	end	4	estriction	1.0	-emailwith	1.0			adherence	2.0					doubt	1.0	schiphol	1.0		
+405	commissioners	5.0	user license	2.0	england	1.0	look	1.0	balancing test	2.0	england	1.0	lease	1.0	balancing test	2.0	hays house north wing	1.0	lease	1.0	close	4	contradiction	1.0	adobe	1.0			access right	2.0					merchandise	1.0	beechavenue	1.0		
+406	check	5.0	balancing test	2.0	contact information	1.0	lease	1.0	evaluation	2.0	support centre	1.0	update edit	1.0	evaluation	2.0	floor millmead guildford surrey england gu2 4hj	1.0	update edit	1.0	datum processing	4	behalf	1.0	site	1.0			variation	2.0					k	1.0	ofdata	1.0		
+407	rely	5.0	assessment	2.0	support centre	1.0	update edit	1.0	assessment	2.0	contact information	1.0	advise	1.0	assessment	2.0	england	1.0	misuse	1.0	individual	4	doubt	1.0	applications	1.0			safeguard	2.0					-emailfrom	1.0	president	1.0		
+408	alternative	5.0	evaluation	2.0	data protection team	1.0	advise	1.0	deactivation page	2.0	data protection team	1.0	misuse	1.0	deactivation page	2.0	contact information	1.0	advise	1.0	email display	4	merchandise	1.0	neptune	1.0			portion	2.0					field	1.0	huuugegroup	1.0		
+409	breach	5.0	deactivation page	2.0	fireproof studios ltd	1.0	misuse	1.0	feedback page	2.0	fireproof studios ltd	1.0	sell	1.0	feedback page	2.0	support centre	1.0	sell	1.0	address provide	4	k	1.0	store	1.0			calendar year	2.0					edit	1.0	sp	1.0		
+410	instance	5.0	feedback page	2.0	sega	1.0	acquire	1.0	attention	2.0	sega	1.0	buy	1.0	attention	2.0	data protection team	1.0	buy	1.0	login	4	-emailfrom	1.0	play	1.0			transmission	2.0					blockage	1.0	huuuge	1.0		
+411	reasonable	5.0	attention	2.0	batemans row london ec2a	1.0	buy	1.0	address book contact	2.0	batemans row london ec2a	1.0	acquire	1.0	address book contact	2.0	fireproof studios ltd	1.0	acquire	1.0	services	4	field	1.0	/apple	1.0			residence	2.0					zone	1.0	900san	1.0		
+412	arise	5.0	address book contact	2.0	pepper deals ltd	1.0	sell	1.0	means	2.0	pepper deals ltd	1.0	deliver	1.0	means	2.0	sega	1.0	deliver	1.0	relate	4	edit	1.0	ellation	1.0			website account	2.0					tech	1.0	officerone	1.0		
+413	unresolved	5.0	means	2.0	ico wycliffe house water lane wilmslow	1.0	deliver	1.0	adherence	2.0	ico wycliffe house water lane wilmslow	1.0	return	1.0	adherence	2.0	batemans row london ec2a	1.0	return	1.0	provide access	4	blockage	1.0	cube	1.0			processing operation	2.0					park	1.0	cumberland	1.0		
+414	satisfactorily	5.0	adherence	2.0	cheshire	1.0	return	1.0	access right	2.0	cheshire	1.0	familiarize	1.0	access right	2.0	pepper deals ltd	1.0	familiarize	1.0	deactivate	4	park	1.0	software	1.0			vat registration number	2.0					operating	1.0	place	1.0		
+415	seek	5.0	access right	2.0	tgtg platform	1.0	familiarize	1.0	variation	2.0	tgtg platform	1.0	jeopardize	1.0	variation	2.0	ico wycliffe house water lane wilmslow	1.0	jeopardize	1.0	member	4	tech	1.0	dashlane	1.0			team	2.0					/settings	1.0	fenian	1.0		
+416	forth	5.0	variation	2.0	k?benhavn sor	1.0	jeopardize	1.0	action	2.0	k?benhavn sor	1.0	triage	1.0	action	2.0	cheshire	1.0	triage	1.0	clause	4	zone	1.0	pierre	1.0			range	2.0					/support	1.0	streetdublin	1.0		
+417	decide	5.0	action	2.0	lindgreens	1.0	triage	1.0	portion	2.0	lindgreens	1.0	anonymise	1.0	portion	2.0	tgtg platform	1.0	anonymise	1.0	preference	4	operating	1.0	picard	1.0			telephone	2.0					code	1.0	ireland	1.0		
+418	switzerland	5.0	portion	2.0	high road east finchley london	1.0	anonymise	1.0	research activity	2.0	high road east finchley london	1.0	enjoy	1.0	research activity	2.0	k?benhavn sor	1.0	enjoy	1.0	business purpose	4	/support	1.0	longyuan	1.0			contact form	2.0					contextlogic	1.0	companys	1.0		
+419	30	5.0	research activity	2.0	restaurants limited customer services	1.0	enjoy	1.0	calendar year	2.0	restaurants limited customer services	1.0	authenticate	1.0	calendar year	2.0	lindgreens	1.0	authenticate	1.0	safeguard	4	code	1.0	network	1.0			address telephone number	2.0					item	1.0	tricor	1.0		
+420	day	5.0	calendar year	2.0	freeview	1.0	authenticate	1.0	transmission	2.0	freeview	1.0	vary	1.0	transmission	2.0	high road east finchley london	1.0	vary	1.0	google	4	contextlogic	1.0	android	1.0			safety	2.0					progress	1.0	mark	1.0		
+421	legislator	5.0	transmission	2.0	uk information commissioners office	1.0	vary	1.0	residence	2.0	uk information commissioners office	1.0	rate	1.0	residence	2.0	restaurants limited customer services	1.0	rate	1.0	interaction	4	progress	1.0	ios	1.0			citizen	2.0					processor	1.0	saygames	1.0		
+422	grant	5.0	residence	2.0	legal department freeview	1.0	rate	1.0	website account	2.0	legal department freeview	1.0			website account	2.0	freeview	1.0			privacy statement	4	item	1.0	-urlfor	1.0			national	2.0					investigation	1.0	cookie	1.0		
+423	point	5.0	website account	2.0	floor	1.0			processing operation	2.0	floor	1.0			processing operation	2.0	uk information commissioners office	1.0			message describe	4	processor	1.0	bbb	1.0			position	1.0					result	1.0	britbox	1.0		
+424	europe	5.0	processing operation	2.0	digital uk limited	1.0			vat registration number	2.0	dtv services ltd	1.0			vat registration number	2.0	legal department freeview	1.0			help service	4	investigation	1.0	sweden	1.0			email list	1.0					receipt	1.0	addressable	1.0		
+425	quickly	5.0	vat registration number	2.0	dtv services ltd	1.0			company number	2.0	digital uk limited	1.0			company number	2.0	floor	1.0			support center	4	result	1.0	stockholm	1.0			letter b	1.0					updating	1.0	square	1.0		
+426	menu	5.0	company number	2.0	data protection act	1.0			team	2.0	data protection act	1.0			team	2.0	dtv services ltd	1.0			create	4	receipt	1.0	brunnsgatan	1.0			boulevard	1.0					juvenile	1.0	waterhouse	1.0		
+427	netherlands	5.0	team	2.0	picsart service	1.0			range	2.0	picsart service	1.0			range	2.0	digital uk limited	1.0			-emailwe	4	updating	1.0	gamegos	1.0			data collection	1.0					mistake	1.0	ec1n	1.0		
+428	response	5.0	range	2.0	professions code section	1.0			telephone	2.0	professions code section	1.0			telephone	2.0	data protection act	1.0			dingtone	4	juvenile	1.0	gametion	1.0			interest marketing	1.0					objection”below	1.0	consumer	1.0		
+429	building	5.0	telephone	2.0	california business	1.0			contact form	2.0	california business	1.0			contact form	2.0	picsart service	1.0			duolingo	4	mistake	1.0	pvt	1.0			expiration	1.0					blog	1.0	gb	1.0		
+430	event	5.0	contact form	2.0	sutter st.	1.0			address telephone number	2.0	picsart inc.	1.0			address telephone number	2.0	professions code section	1.0			platform	4	objection”below	1.0	m	1.0			justification	1.0					applier	1.0	media	1.0		
+431	san	5.0	address telephone number	2.0	picsart inc.	1.0			safety	2.0	sutter st.	1.0			safety	2.0	picsart inc.	1.0			drawer	4	blog	1.0	liverpool	1.0			datum protection officer	1.0					acquisition	1.0	fremantle	1.0		
+432	reuters	5.0	safety	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			citizen	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			citizen	2.0	california business	1.0			contact email	3	applier	1.0	ec2	1.0			datum protection issue	1.0					circumstancesfor	1.0	stephen	1.0		
+433	thomson	5.0	national	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			national	2.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			national	2.0	sutter st.	1.0			sharing	3	acquisition	1.0	gogogame	1.0			datum subject access request	1.0					ctr	1.0	factor	1.0		
+434	extent	5.0	citizen	2.0	brexit csr press centre	1.0			position	1.0	services uk europe	1.0			position	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by.you	1.0			browser setting	3	circumstancesfor	1.0	shepherds	1.0			data accuracy	1.0					document	1.0	x	1.0		
+435	lead	5.0	position	1.0	services uk europe	1.0			email list	1.0	dpd terms	1.0			email list	1.0	dpdgroup uk ltd roebuck lane smethwick b66 1by products	1.0			establish	3	ctr	1.0	w14	1.0			scenario	1.0					viii	1.0	talent	1.0		
+436	future	5.0	email list	1.0	international dpd	1.0			letter b	1.0	international dpd	1.0			letter b	1.0	services uk europe	1.0			remedy	3	document	1.0	good	1.0			deletion obligation	1.0					filter	1.0	got	1.0		
+437	confirm	5.0	letter b	1.0	dpd terms	1.0			boulevard	1.0	brexit csr press centre	1.0			boulevard	1.0	international dpd	1.0			customer service	3	viii	1.0	catch	1.0			user behaviour	1.0					meaning	1.0	britain	1.0		
+438	occur	5.0	boulevard	1.0	update	1.0			data collection	1.0	conditions	1.0			data collection	1.0	dpd terms	1.0			load terms	3	filter	1.0	building	1.0			termination	1.0					present	1.0	hydrane	1.0		
+439	15	5.0	data collection	1.0	conditions	1.0			interest marketing	1.0	update	1.0			interest marketing	1.0	brexit csr press centre	1.0			game setting	3	meaning	1.0	central	1.0			delete	1.0					health	1.0	linkedin	1.0		
+440	rule	5.0	interest marketing	1.0	apple	1.0			expiration	1.0	apple	1.0			expiration	1.0	conditions	1.0			follow instruction	3	present	1.0	charecroft	1.0			data transferability	1.0					caregiver	1.0	jobs	1.0		
+441	assistance	5.0	expiration	1.0	european data protection officer	1.0			justification	1.0	european data protection officer	1.0			justification	1.0	update	1.0			section request	3	health	1.0	way	1.0			obstruction	1.0					professional	1.0	blog	1.0		
+442	desire	5.0	justification	1.0	apples privacy policy	1.0			datum protection officer	1.0	apples privacy policy	1.0			datum protection officer	1.0	apple	1.0			eea-base user	3	professional	1.0	java	1.0			app setting	1.0					port	1.0	careers	1.0		
+443	close	5.0	datum protection officer	1.0	apec cbpr	1.0			datum protection issue	1.0	apec cbpr	1.0			datum protection issue	1.0	european data protection officer	1.0			version	3	care	1.0	schiphol	1.0			datum protection regulation	1.0					rectify	1.0	articles	1.0		
+444	identity	5.0	datum protection issue	1.0	prp	1.0			datum subject access request	1.0	prp	1.0			datum subject access request	1.0	apples privacy policy	1.0			follow way	3	caregiver	1.0	rijk	1.0			portal	1.0					status	1.0	events	1.0		
+445	login	5.0	datum subject access request	1.0	commitment	1.0			data accuracy	1.0	commitment	1.0			data accuracy	1.0	apec cbpr	1.0			removal	3	rectify	1.0	beechavenue	1.0			email address -email-	1.0					compilation	1.0	companyabout	1.0		
+446	click	5.0	data accuracy	1.0	privacyto	1.0			scenario	1.0	privacyto	1.0			scenario	1.0	prp	1.0			decision	3	status	1.0	grab	1.0			current	1.0					outlet	1.0	city	1.0		
+447	far	5.0	scenario	1.0	apple support	1.0			deletion obligation	1.0	apple support	1.0			deletion obligation	1.0	commitment	1.0			enforce	3	compilation	1.0	applicationsor	1.0			email preference	1.0					area	1.0	usaemail	1.0		
+448	affect	5.0	deletion obligation	1.0	calabasas rd calabasas	1.0			termination	1.0	calabasas rd calabasas	1.0			termination	1.0	privacyto	1.0			owner	3	area	1.0	president	1.0			member profile	1.0					institution	1.0	culver	1.0		
+449	automated	5.0	user behaviour	1.0	planetart llc	1.0			user behaviour	1.0	planetart llc	1.0			user behaviour	1.0	apple support	1.0			hindrance	3	outlet	1.0	ofdata	1.0			forum account	1.0					imo	1.0	blvd	1.0		
+450	telephone	5.0	termination	1.0	customer care	1.0			delete	1.0	customer care	1.0			delete	1.0	calabasas rd calabasas	1.0			privacy policy include	3	institution	1.0	huuugegroup	1.0			support account	1.0					learning	1.0	venice	1.0		
+451	maintain	5.0	delete	1.0	notification settings	1.0			data transferability	1.0	account settings	1.0			data transferability	1.0	planetart llc	1.0			entity	3	imo	1.0	sp	1.0			users datum	1.0					hn	1.0	october	1.0		
+452	deactivate	5.0	data transferability	1.0	account settings	1.0			obstruction	1.0	notification settings	1.0			obstruction	1.0	customer care	1.0			information commissioners office	3	d	1.0	huuuge	1.0			support widget	1.0					opinion	1.0	wc2b	1.0		
+453	shield	5.0	obstruction	1.0	center	1.0			app setting	1.0	center	1.0			app setting	1.0	account settings	1.0			request restriction	3	learning	1.0	ireland	1.0			expression	1.0					signature	1.0	summarywhat	1.0		
+454	ooo	5.0	app setting	1.0	datainspektionen	1.0			registration account	1.0	datainspektionen	1.0			registration account	1.0	notification settings	1.0			limitation	3	hn	1.0	900san	1.0			evidence	1.0					job	1.0	kingsway	1.0		
+455	safeguard	5.0	registration account	1.0	w 18th street	1.0			exit	1.0	new york ny	1.0			exit	1.0	center	1.0			protection	3	opinion	1.0	cumberland	1.0			authoriy	1.0					left	1.0	aviation	1.0		
+456	emailwe	5.0	exit	1.0	new york ny	1.0			datum protection regulation	1.0	w 18th street	1.0			datum protection regulation	1.0	datainspektionen	1.0			entry	3	signature	1.0	place	1.0			process	1.0					treatment	1.0	bytedance	1.0		
+457	similar	5.0	datum protection regulation	1.0					portal	1.0					portal	1.0	new york ny	1.0			datum store	3	job	1.0	fenian	1.0			pay phone	1.0					advertiser	1.0	wish	1.0		
+458	apple	5.0	portal	1.0					email address -email-	1.0					email address -email-	1.0	w 18th street	1.0			jaumo	3	left	1.0	companys	1.0			call	1.0					review	1.0	listmania	1.0		
+459	homa	5.0	email address -email-	1.0					current	1.0					current	1.0					effort	3	treatment	1.0	tricor	1.0			mobile	1.0					timeline	1.0	recommendations	1.0		
+460	sharing	4.0	current	1.0					email preference	1.0					email preference	1.0					replace	3	advertiser	1.0	mark	1.0			principle	1.0					-urland	1.0	wedding	1.0		
+461	accordingly	4.0	email preference	1.0					member profile	1.0					member profile	1.0					avatar	3	timeline	1.0	platonova	1.0			mondly	1.0					affiliate	1.0	baby	1.0		
+462	establish	4.0	member profile	1.0					forum account	1.0					forum account	1.0					photo	3	-urland	1.0	britbox	1.0			dot	1.0					rider	1.0	recommended	1.0		
+463	administrative	4.0	support account	1.0					support account	1.0					support account	1.0					reside	3	affiliate	1.0	addressable	1.0			com	1.0					submission	1.0	lists	1.0		
+464	additionally	4.0	forum account	1.0					users datum	1.0					users datum	1.0					use format	3	rider	1.0	waterhouse	1.0			opt	1.0					court	1.0	delivers	1.0		
+465	urlfor	4.0	users datum	1.0					support widget	1.0					support widget	1.0					newsletter	3	submission	1.0	square	1.0			data stock	1.0					liability	1.0	alerts	1.0		
+466	previous	4.0	support widget	1.0					correct	1.0					correct	1.0					suggestion regard	3	court	1.0	ec1n	1.0			storage obligation	1.0					secret	1.0	availability	1.0		
+467	research	4.0	correct	1.0					evidence	1.0					expression	1.0					rely	3	liability	1.0	factor	1.0			indication	1.0					trade	1.0	product	1.0		
+468	entity	4.0	evidence	1.0					expression	1.0					evidence	1.0					decline	3	secret	1.0	consumer	1.0			declaration	1.0					gdprbot	1.0	4hj	1.0		
+469	limitation	4.0	expression	1.0					ight	1.0					ight	1.0					process pende	3	trade	1.0	x	1.0			controller rectification	1.0					possession	1.0	gu2	1.0		
+470	assert	4.0	ight	1.0					authoriy	1.0					authoriy	1.0					processing override	3	voice	1.0	fremantle	1.0			following	1.0					flat	1.0	england	1.0		
+471	enter	4.0	authoriy	1.0					pay phone	1.0					call	1.0					authority situate	3	gdprbot	1.0	britain	1.0			possibility	1.0					ip	1.0	surrey	1.0		
+472	completely	4.0	pay phone	1.0					call	1.0					pay phone	1.0					server	3	possession	1.0	got	1.0			paragraph e	1.0					po	1.0	guildford	1.0		
+473	requirement	4.0	call	1.0					mobile	1.0					mobile	1.0					information associate	3	flat	1.0	talent	1.0			destruction process	1.0					transparency	1.0	millmead	1.0		
+474	nature	4.0	mobile	1.0					principle	1.0					principle	1.0					party dispute resolution provider	3	ip	1.0	stephen	1.0			recovery	1.0					people	1.0	wing	1.0		
+475	photo	4.0	principle	1.0					mondly	1.0					mondly	1.0					revise	3	po	1.0	gb	1.0			manager contact information section	1.0					tweet	1.0	north	1.0		
+476	outside	4.0	mondly	1.0					dot	1.0					dot	1.0					account setting section	3	transparency	1.0	media	1.0			application setting menu	1.0					arbitration	1.0	hays	1.0		
+477	decline	4.0	dot	1.0					com	1.0					com	1.0					withdrawal	3	people	1.0	hydrane	1.0			user analytic procedure	1.0					participation	1.0	ec2a	1.0		
+478	fee	4.0	com	1.0					opt	1.0					opt	1.0					efta states	3	tweet	1.0	blog	1.0			registration information	1.0					accountability	1.0	row	1.0		
+479	verification	4.0	opt	1.0					data stock	1.0					data stock	1.0					time contact	3	arbitration	1.0	linkedin	1.0			power	1.0					touch	1.0	batemans	1.0		
+480	habitual	4.0	data stock	1.0					indication	1.0					indication	1.0					controller restriction	3	participation	1.0	articles	1.0			conduct	1.0					amend	1.0	deals	1.0		
+481	server	4.0	storage obligation	1.0					storage obligation	1.0					storage obligation	1.0					point	3	accountability	1.0	events	1.0			website application	1.0					-emailwith	1.0	pepper	1.0		
+482	portal	4.0	indication	1.0					declaration	1.0					declaration	1.0					link	3	touch	1.0	careers	1.0			help page	1.0					dissemination	1.0	cheshire	1.0		
+483	sign	4.0	declaration	1.0					controller rectification	1.0					controller rectification	1.0					faith effort	3	amend	1.0	jobs	1.0			estriction	1.0					tablet	1.0	wilmslow	1.0		
+484	resolution	4.0	controller rectification	1.0					following	1.0					following	1.0					follow circumstance	3	-emailwith	1.0	companyabout	1.0			data protection legislation	1.0					computer	1.0	water	1.0		
+485	permission	4.0	following	1.0					possibility	1.0					possibility	1.0					destroy	3	dissemination	1.0	.california	1.0			contradiction	1.0					organization	1.0	wycliffe	1.0		
+486	revoke	4.0	possibility	1.0					paragraph e	1.0					paragraph e	1.0					encourage	3	computer	1.0	october	1.0			marketing advertising	1.0					-emailany	1.0	sor	1.0		
+487	related	4.0	paragraph e	1.0					destruction process	1.0					destruction process	1.0					possess	3	tablet	1.0	venice	1.0			promotion purpose	1.0					action	1.0	k?benhavn	1.0		
+488	unable	4.0	destruction process	1.0					recovery	1.0					recovery	1.0					correction contain	3	organization	1.0	blvd	1.0			advertising purpose	1.0					relationship	1.0	lindgreens	1.0		
+489	personalized	4.0	recovery	1.0					manager contact information section	1.0					manager contact information section	1.0					barbara strozzilaan	3	-emailany	1.0	culver	1.0			behalf	1.0					acknowledgement	1.0	mcdonald	1.0		
+490	withdrawal	4.0	manager contact information section	1.0					application setting menu	1.0					application setting menu	1.0					device setting	3	relationship	1.0	city	1.0			doubt	1.0					network	1.0	finchley	1.0		
+491	partner	4.0	application setting menu	1.0					user analytic procedure	1.0					user analytic procedure	1.0					answer	3	acknowledgement	1.0	usaemail	1.0			device ad identifier	1.0					internet	1.0	east	1.0		
+492	procedure	4.0	user analytic procedure	1.0					registration information	1.0					registration information	1.0					technology	3	network	1.0	bytedance	1.0			merchandise	1.0					blocking	1.0	high	1.0		
+493	existence	4.0	registration information	1.0					power	1.0					power	1.0					query regard	3	internet	1.0	aviation	1.0			marketing preference	1.0					username	1.0	restaurants	1.0		
+494	handling	4.0	power	1.0					conduct	1.0					conduct	1.0					inaccuracy correct	3	blocking	1.0	kingsway	1.0			customer service department	1.0					source	1.0	freeview	1.0		
+495	11	4.0	conduct	1.0					website application	1.0					website application	1.0					process datum	3	username	1.0	wc2b	1.0			k account information	1.0					sentence	1.0	dtv	1.0		
+496	error	4.0	website application	1.0					help page	1.0					help page	1.0					data protection supervisory authority	3	source	1.0	summarywhat	1.0			email account	1.0					processingof	1.0	professions	1.0		
+497	44	4.0	help page	1.0					estriction	1.0					estriction	1.0					contact support service	3	sentence	1.0	contractual	1.0			-emailfrom	1.0					portabilityof	1.0	st.	1.0		
+498	analytic	4.0	estriction	1.0					data protection legislation	1.0					data protection legislation	1.0					circumstance require	3	processingof	1.0	ironhide	1.0			subject field	1.0					authorityabout	1.0	sutter	1.0		
+499	ensure	4.0	data protection legislation	1.0					contradiction	1.0					contradiction	1.0					datum portability	3	portabilityof	1.0	flash	1.0			nickname	1.0					companyattn	1.0	1by.you	1.0		
+500	investigate	4.0	contradiction	1.0					marketing advertising	1.0					marketing advertising	1.0					deal	3	authorityabout	1.0	list	1.0			subject line	1.0					holder	1.0	dpdgroup	1.0		
+501	indicate	4.0	marketing advertising	1.0					promotion purpose	1.0					promotion purpose	1.0					usa	3	companyattn	1.0	product	1.0			restrict correct	1.0					s	1.0	dpd	1.0		
+502	ny	4.0	promotion purpose	1.0					advertising purpose	1.0					advertising purpose	1.0					block	3	holder	1.0	recommended	1.0			edit	1.0					plan	1.0	press	1.0		
+503	new	4.0	advertising purpose	1.0					behalf	1.0					behalf	1.0					database	3	s	1.0	wedding	1.0			rectification right	1.0					material	1.0	csr	1.0		
+504	permanently	4.0	behalf	1.0					doubt	1.0					doubt	1.0					view update	3	plan	1.0	wish	1.0			complaint erasure	1.0					eea	1.0	products	1.0		
+505	adjust	4.0	doubt	1.0					device ad identifier	1.0					device ad identifier	1.0					service change	3	material	1.0	availability	1.0			blockage	1.0					ec3r	1.0	brexit	1.0		
+506	francisco	4.0	device ad identifier	1.0					merchandise	1.0					merchandise	1.0					locate	3	eea	1.0	alerts	1.0			game account	1.0					suite	1.0	1by	1.0		
+507	head	4.0	merchandise	1.0					marketing preference	1.0					marketing preference	1.0					effect	3	ec3r	1.0	delivers	1.0			storage purpose	1.0					part	1.0	conditions	1.0		
+508	abuse	4.0	marketing preference	1.0					customer service department	1.0					customer service department	1.0					support service	3	suite	1.0	baby	1.0			software park	1.0					lawfulness	1.0	update	1.0		
+509	raise	4.0	customer service department	1.0					k account information	1.0					k account information	1.0					privacy practice relate	3	part	1.0	recommendations	1.0			tech zone	1.0					volume	1.0	privacyto	1.0		
+510	body	4.0	k account information	1.0					email account	1.0					email account	1.0					gdpr include information	3	lawfulness	1.0	listmania	1.0			building	1.0					traffic	1.0	apples	1.0		
+511	step	4.0	email account	1.0					nickname	1.0					-emailfrom	1.0					support form	3	base	1.0	4hj	1.0			operating system setting	1.0					pattern	1.0	commitment	1.0		
+512	representative	4.0	subject field	1.0					-emailfrom	1.0					nickname	1.0					raise	3	sale	1.0	gu2	1.0			tracking	1.0					sale	1.0	prp	1.0		
+513	webmartgroup	4.0	-emailfrom	1.0					subject field	1.0					subject field	1.0					aim	3	pattern	1.0	hays	1.0			identifier	1.0					base	1.0	cbpr	1.0		
+514	present	4.0	nickname	1.0					subject line	1.0					subject line	1.0					strive	3	traffic	1.0	north	1.0			account setting page	1.0					group	1.0	apec	1.0		
+515	unlawful	4.0	subject line	1.0					restrict correct	1.0					restrict correct	1.0					review edit	3	volume	1.0	wing	1.0			/settings	1.0					producer	1.0	calabasas	1.0		
+516	problem	4.0	restrict correct	1.0					edit	1.0					edit	1.0					profile section	3	group	1.0	millmead	1.0			/support	1.0					programme	1.0	rd	1.0		
+517	select	4.0	edit	1.0					rectification right	1.0					rectification right	1.0					subject	3	producer	1.0	guildford	1.0			proof	1.0					ico	1.0	planetart	1.0		
+518	explanation	4.0	rectification right	1.0					complaint erasure	1.0					complaint erasure	1.0					datum storage	3	programme	1.0	surrey	1.0			registry code	1.0					death	1.0	care	1.0		
+519	web	4.0	complaint erasure	1.0					blockage	1.0					blockage	1.0					privacy setting	3	ico	1.0	pepper	1.0			unsubscribe option	1.0					publishing	1.0	notification	1.0		
+520	icbc	4.0	blockage	1.0					game account	1.0					game account	1.0					set	3	death	1.0	deals	1.0			promotion	1.0					choicesyou	1.0	datainspektionen	1.0		
+521	function	4.0	game account	1.0					storage purpose	1.0					storage purpose	1.0					seek	3	t	1.0	batemans	1.0			device location	1.0					platform	1.0	18th	1.0		
+522	postal	4.0	storage purpose	1.0					software park	1.0					software park	1.0					support page	3	publishing	1.0	row	1.0			device privacy setting	1.0					contactquestion	1.0	netflix	1.0		
+523	emailfor	4.0	tech zone	1.0					tech zone	1.0					tech zone	1.0					request copy	3	choicesyou	1.0	ec2a	1.0			location sharing	1.0					-emailprivacy	1.0				
+524	read	4.0	software park	1.0					operating system setting	1.0					operating system setting	1.0					iii	3	platform	1.0	cheshire	1.0			tab	1.0					complaintsin	1.0				
+525	clause	4.0	operating system setting	1.0					tracking	1.0					tracking	1.0					matter cover	3	contactquestion	1.0	wycliffe	1.0			datum use practice	1.0					manufacturer	1.0				
+526	non	4.0	tracking	1.0					identifier	1.0					identifier	1.0					modification	3	-emailprivacy	1.0	water	1.0			contextlogic use	1.0					on	1.0				
+527	interaction	4.0	identifier	1.0					account setting page	1.0					account setting page	1.0					functionality	3	rightsyou	1.0	wilmslow	1.0			user id number	1.0					gift	1.0				
+528	tekhnolodzhi	4.0	account setting page	1.0					/support	1.0					/settings	1.0					explanation	3	complaintsin	1.0	lindgreens	1.0			progress	1.0					card	1.0				
+529	yumobi	4.0	/settings	1.0					/settings	1.0					/support	1.0					floor	3	manufacturer	1.0	k?benhavn	1.0			item	1.0					recommendation	1.0				
+530	correspond	4.0	/support	1.0					registry code	1.0					registry code	1.0					setting section	3	recommendation	1.0	sor	1.0			site service application	1.0					wish	1.0				
+531	password	4.0	registry code	1.0					unsubscribe option	1.0					unsubscribe option	1.0					ve provide	3	click	1.0	high	1.0			support ticket	1.0					unit	1.0				
+532	dingtone	4.0	unsubscribe option	1.0					promotion	1.0					promotion	1.0					add update	3	gift	1.0	restaurants	1.0			information object	1.0					beginning	1.0				
+533	operation	4.0	promotion	1.0					device location	1.0					device location	1.0					data practice	3	wish	1.0	east	1.0			processor	1.0					language	1.0				
+534	tgtg	4.0	device location	1.0					device privacy setting	1.0					device privacy setting	1.0					datum base	3	card	1.0	finchley	1.0			mail address -email-	1.0					subscription	1.0				
+535	spotify	4.0	device privacy setting	1.0					location sharing	1.0					location sharing	1.0					web form	3	reminder	1.0	dtv	1.0			correction addition	1.0					fax	1.0				
+536	judicial	3.0	location sharing	1.0					tab	1.0					tab	1.0					marketing processing base	3	shopping	1.0	sutter	1.0			investigation	1.0					minor	1.0				
+537	tower	3.0	tab	1.0					datum use practice	1.0					datum use practice	1.0					function	3	unit	1.0	st.	1.0			result	1.0					push	1.0				
+538	load	3.0	datum use practice	1.0					contextlogic use	1.0					contextlogic use	1.0					maintain	3	beginning	1.0	professions	1.0			restrict limit	1.0					sms	1.0				
+539	version	3.0	contextlogic use	1.0					user id number	1.0					user id number	1.0					in-game	3	language	1.0	dpdgroup	1.0			receipt	1.0					asset	1.0				
+540	gather	3.0	user id number	1.0					progress	1.0					progress	1.0					read	3	subscription	1.0	1by.you	1.0			address -email-	1.0					buyer	1.0				
+541	automatic	3.0	item	1.0					item	1.0					item	1.0					information request	3	fax	1.0	dpd	1.0			app section	1.0					duty	1.0				
+542	period	3.0	progress	1.0					site service application	1.0					site service application	1.0					interest right	3	minor	1.0	1by	1.0			communication feature	1.0					policythis	1.0				
+543	hindrance	3.0	site service application	1.0					support ticket	1.0					support ticket	1.0					comment regard	3	push	1.0	products	1.0			collection use disclosure	1.0					parcel	1.0				
+544	lawfully	3.0	support ticket	1.0					information object	1.0					information object	1.0					datum infringe datum protection law	3	sms	1.0	update	1.0			access updating	1.0					surcharge	1.0				
+545	natural	3.0	information object	1.0					processor	1.0					processor	1.0					tantan	3	asset	1.0	brexit	1.0			juvenile	1.0					fuel	1.0				
+546	para	3.0	processor	1.0					mail address -email-	1.0					mail address -email-	1.0					approach specify	3	buyer	1.0	csr	1.0			datum datum portability	1.0					schedule	1.0				
+547	entry	3.0	mail address -email-	1.0					correction addition	1.0					correction addition	1.0					supervisory authority	3	duty	1.0	press	1.0			datum objection	1.0					sitemap	1.0				
+548	jaumo	3.0	correction addition	1.0					investigation	1.0					investigation	1.0					nekki limited	3	policythis	1.0	conditions	1.0			data rectification	1.0					award	1.0				
+549	entire	3.0	investigation	1.0					result	1.0					result	1.0					registration number	3	parcel	1.0	apec	1.0			file erasure	1.0					career	1.0				
+550	anonymous	3.0	result	1.0					restrict limit	1.0					restrict limit	1.0					change update	3	pickup	1.0	cbpr	1.0			mistake	1.0					franchise	1.0				
+551	avatar	3.0	restrict limit	1.0					receipt	1.0					receipt	1.0					support e-mail	3	schedule	1.0	prp	1.0			blog	1.0					vacancy	1.0				
+552	replace	3.0	receipt	1.0					address -email-	1.0					address -email-	1.0					fulfil	3	award	1.0	commitment	1.0			forum	1.0					postcode	1.0				
+553	emailto	3.0	address -email-	1.0					app section	1.0					app section	1.0					occur	3	career	1.0	privacyto	1.0			member information page	1.0					phishing	1.0				
+554	cancel	3.0	app section	1.0					communication feature	1.0					communication feature	1.0					regulator	3	vacancy	1.0	calabasas	1.0			communication option	1.0					moment	1.0				
+555	lingodeer	3.0	communication feature	1.0					collection use disclosure	1.0					collection use disclosure	1.0					twitter	3	surcharge	1.0	rd	1.0			applier	1.0					certification	1.0				
+556	unauthorized	3.0	collection use disclosure	1.0					access updating	1.0					access updating	1.0					twitter international company	3	franchise	1.0	planetart	1.0			acquisition processing restriction	1.0					guideline	1.0				
+557	pende	3.0	access updating	1.0					juvenile	1.0					juvenile	1.0					yumobi tekhnolodzhi ooo	3	sitemap	1.0	care	1.0			correction update amendment	1.0					region	1.0				
+558	situate	3.0	juvenile	1.0					datum datum portability	1.0					datum datum portability	1.0					display	3	moment	1.0	notification	1.0			data access request	1.0					reply	1.0				
+559	anytime	3.0	datum datum portability	1.0					datum objection	1.0					datum objection	1.0					password	3	certification	1.0	datainspektionen	1.0			datum request	1.0					conjunction	1.0				
+560	forum	3.0	datum objection	1.0					data rectification	1.0					data rectification	1.0					infringement	3	guideline	1.0	18th	1.0			circumstancesfor example	1.0					ease	1.0				
+561	based	3.0	file erasure	1.0					file erasure	1.0					file erasure	1.0					attempt	3	region	1.0					ctr	1.0					prevention	1.0				
+562	revise	3.0	data rectification	1.0					mistake	1.0					mistake	1.0					help center	3	reply	1.0					customer service email address	1.0					credit	1.0				
+563	specifically	3.0	mistake	1.0					objection”below	1.0					objection”below	1.0					google account	3	conjunction	1.0					document	1.0					fraud	1.0				
+564	easily	3.0	objection”below	1.0					blog	1.0					blog	1.0					privacy matter	3	ease	1.0					account information update	1.0					audit	1.0				
+565	accept	3.0	forum	1.0					forum	1.0					forum	1.0					processing base	3	credit	1.0					party tracking	1.0					tax	1.0				
+566	exemption	3.0	blog	1.0					member information page	1.0					member information page	1.0					tgtg account	3	tax	1.0					right interest	1.0					accounting	1.0				
+567	cost	3.0	member information page	1.0					communication option	1.0					communication option	1.0					address state	2	audit	1.0					viii	1.0					note	1.0				
+568	analytics	3.0	communication option	1.0					applier	1.0					applier	1.0					keyword data protection	2	accounting	1.0					filter	1.0										
+569	experience	3.0	applier	1.0					acquisition processing restriction	1.0					acquisition processing restriction	1.0					result	2	fraud	1.0					user content	1.0										
+570	publisher	3.0	acquisition processing restriction	1.0					correction update amendment	1.0					correction update amendment	1.0					pre-condition	2	prevention	1.0					meaning	1.0										
+571	confidentially	3.0	correction update amendment	1.0					data access request	1.0					data access request	1.0					datum provide	2	note	1.0					present	1.0										
+572	statutory	3.0	data access request	1.0					datum request	1.0					datum request	1.0					hinderance	2							privacy concern complaint	1.0										
+573	faith	3.0	datum request	1.0					circumstancesfor example	1.0					circumstancesfor example	1.0					data processing base	2							health datum	1.0										
+574	destroy	3.0	circumstancesfor example	1.0					ctr	1.0					ctr	1.0					advertisement	2							health care professional	1.0										
+575	encourage	3.0	ctr	1.0					customer service email address	1.0					customer service email address	1.0					contact provide	2							family caregiver	1.0										
+576	paris	3.0	customer service email address	1.0					document	1.0					document	1.0					appeal	2							rectify port	1.0										
+577	possess	3.0	document	1.0					account information update	1.0					account information update	1.0					delete inaccuracy	2							status update	1.0										
+578	independently	3.0	account information update	1.0					party tracking	1.0					party tracking	1.0					singapore	2							request email	1.0										
+579	true	3.0	party tracking	1.0					right interest	1.0					right interest	1.0					question contact	2							time information	1.0										
+580	amsterdam	3.0	right interest	1.0					iii	1.0					viii	1.0					send complaint	2							user profile	1.0										
+581	strozzilaan	3.0	viii	1.0					viii	1.0					filter	1.0					privacy email	2							compilation	1.0										
+582	barbara	3.0	filter	1.0					filter	1.0					user content	1.0					contact service page	2							data transfer tool	1.0										
+583	201	3.0	user content	1.0					user content	1.0					meaning	1.0					gather	2							balance	1.0										
+584	1083	3.0	meaning	1.0					meaning	1.0					present	1.0					reject	2							mail -email-	1.0										
+585	hn	3.0	present	1.0					present	1.0					privacy concern complaint	1.0					owner contact email	2							area	1.0										
+586	upload	3.0	privacy concern complaint	1.0					privacy concern complaint	1.0					health datum	1.0					aspect	2							outlet	1.0										
+587	answer	3.0	health care professional	1.0					health datum	1.0					health care professional	1.0					detail set	2							institution	1.0										
+588	technology	3.0	health datum	1.0					health care professional	1.0					family caregiver	1.0					suspend	2							imo account	1.0										
+589	legislation	3.0	family caregiver	1.0					family caregiver	1.0					rectify port	1.0					assert exercise	2							download	1.0										
+590	commission	3.0	rectify port	1.0					rectify port	1.0					status update	1.0					defend	2							rectification erasure	1.0										
+591	solely	3.0	status update	1.0					status update	1.0					telephone number	1.0					union	2							child user	1.0										
+592	line	3.0	telephone number	1.0					telephone number	1.0					request email	1.0					lift	2							learning	1.0										
+593	social	3.0	request email	1.0					request email	1.0					time information	1.0					exception	2							hn	1.0										
+594	internet	3.0	time information	1.0					time information	1.0					user profile	1.0					membership	2							case access	1.0										
+595	interactive	3.0	user profile	1.0					user profile	1.0					compilation	1.0					terminate	2							question complaint	1.0										
+596	york	3.0	compilation	1.0					compilation	1.0					data transfer tool	1.0					correct delete	2							question opinion	1.0										
+597	tandem	3.0	data transfer tool	1.0					data transfer tool	1.0					balance	1.0					involve	2							nickname profile photo signature job	1.0										
+598	software	3.0	balance	1.0					balance	1.0					mail -email-	1.0					feature	2							address information interest question	1.0										
+599	deal	3.0	mail -email-	1.0					mail -email-	1.0					area	1.0					send email	2							answer	1.0										
+600	usa	3.0	area	1.0					outlet	1.0					outlet	1.0					violate	2							left	1.0										
+601	professional	3.0	outlet	1.0					area	1.0					institution	1.0					infringe	2							treatment	1.0										
+602	satisfied	3.0	institution	1.0					institution	1.0					imo account	1.0					livu application	2							interest page	1.0										
+603	settings	3.0	imo account	1.0					imo account	1.0					download	1.0					scope	2							controller section	1.0										
+604	database	3.0	download	1.0					download	1.0					rectification erasure	1.0					visitor	2							datum privacy practice	1.0										
+605	code	3.0	rectification erasure	1.0					rectification erasure	1.0					child user	1.0					email use	2							party advertiser	1.0										
+606	agent	3.0	child user	1.0					child user	1.0					learning	1.0					testimonial	2							partner	1.0										
+607	location	3.0	learning	1.0					learning	1.0					hn	1.0					restore	2							review update	1.0										
+608	committed	3.0	hn	1.0					hn	1.0					case access	1.0					datum privacy	2							profile tab	1.0										
+609	technologies	3.0	case access	1.0					case access	1.0					question complaint	1.0					instruct	2							data retention timeline	1.0										
+610	zuuks	3.0	question complaint	1.0					question complaint	1.0					question opinion	1.0					assert	2							data protection regulation	1.0										
+611	port	3.0	question opinion	1.0					question opinion	1.0					nickname profile photo signature job	1.0					revoke consent	2							regulation	1.0										
+612	act	3.0	nickname profile photo signature job	1.0					nickname profile photo signature job	1.0					address information interest question	1.0					privacy issue	2							-urland	1.0										
+613	effect	3.0	address information interest question	1.0					address information interest question	1.0					left	1.0					google analytics	2							party information disclosure	1.0										
+614	ofinterest	3.0	left	1.0					left	1.0					treatment	1.0					advertising experience	2							access correction	1.0										
+615	wrong	3.0	treatment	1.0					treatment	1.0					interest page	1.0					exercise control	2							deletion request	1.0										
+616	aim	3.0	interest page	1.0					interest page	1.0					controller section	1.0					account tool	2							information processing	1.0										
+617	strive	3.0	controller section	1.0					controller section	1.0					datum privacy practice	1.0					publisher partner	2							security question	1.0										
+618	remain	3.0	datum privacy practice	1.0					datum privacy practice	1.0					party advertiser	1.0					association	2							account profile	1.0										
+619	young	3.0	party advertiser	1.0					party advertiser	1.0					partner	1.0					advertising demand partner account	2							game support menu	1.0										
+620	category	3.0	partner	1.0					partner	1.0					review update	1.0					revoke	2							affiliate	1.0										
+621	end	3.0	review update	1.0					profile tab	1.0					profile tab	1.0					employee	2							delivery recipient	1.0										
+622	legally	3.0	profile tab	1.0					review update	1.0					data retention timeline	1.0					ground apply	2							delivery partner	1.0										
+623	iii	3.0	data retention timeline	1.0					data retention timeline	1.0					data protection regulation	1.0					resolve issue	2							rider	1.0										
+624	cover	3.0	data protection regulation	1.0					data protection regulation	1.0					regulation	1.0					paris france	2							phone number	1.0										
+625	modification	3.0	regulation	1.0					regulation	1.0					-urland	1.0					request form	2							setting menu	1.0										
+626	functionality	3.0	-urland	1.0					-urland	1.0					party information disclosure	1.0					hn amsterdam	2							datum information	1.0										
+627	cyprus	3.0	party information disclosure	1.0					party information disclosure	1.0					deletion request	1.0					information collection	2							datum rectification	1.0										
+628	corresponding	3.0	deletion request	1.0					deletion request	1.0					access correction	1.0					summary	2							submission	1.0										
+629	channel	3.0	access correction	1.0					access correction	1.0					information processing	1.0					automate mean	2							party company	1.0										
+630	imo	3.0	information processing	1.0					information processing	1.0					security question	1.0					time withdraw	2							court order	1.0										
+631	play	3.0	security question	1.0					security question	1.0					account profile	1.0					datum relate	2							-url- user	1.0										
+632	lion	3.0	account profile	1.0					account profile	1.0					game support menu	1.0					receive information	2							liability	1.0										
+633	swiss	3.0	game support menu	1.0					game support menu	1.0					affiliate	1.0					device delete	2							destruction	1.0										
+634	timely	3.0	affiliate	1.0					affiliate	1.0					delivery recipient	1.0					reset	2							trade secret	1.0										
+635	tantan	3.0	delivery recipient	1.0					delivery recipient	1.0					delivery partner	1.0					take-two	2							property	1.0										
+636	approach	3.0	delivery partner	1.0					delivery partner	1.0					rider	1.0					internet privacy policy administrator	2							data protection practice	1.0										
+637	medium	3.0	rider	1.0					rider	1.0					phone number	1.0					street new york ny	2							support center	1.0										
+638	amino	3.0	phone number	1.0					phone number	1.0					setting menu	1.0					legislation	2							data policy	1.0										
+639	misuse	3.0	setting menu	1.0					setting menu	1.0					datum information	1.0					game account	2							gdprbot	1.0										
+640	nekki	3.0	datum information	1.0					datum information	1.0					datum rectification	1.0					tracking	2							privacy regulator	1.0										
+641	particularly	3.0	datum rectification	1.0					datum rectification	1.0					submission	1.0					collect information	2							possession	1.0										
+642	driver	3.0	submission	1.0					submission	1.0					party company	1.0					transformation	2							datum protection regulator	1.0										
+643	delivery	3.0	party company	1.0					party company	1.0					court order	1.0					opportunity	2							building flat	1.0										
+644	saygames	3.0	court order	1.0					court order	1.0					-url- user	1.0					professional	2							security measure	1.0										
+645	create	3.0	-url- user	1.0					-url- user	1.0					liability	1.0					thomson reuters	2							ip address	1.0										
+646	fulfil	3.0	liability	1.0					liability	1.0					destruction	1.0					uk limited	2							-emailor po box	1.0										
+647	deactivation	3.0	destruction	1.0					destruction	1.0					trade secret	1.0					rectify erase	2							account security marketing preference app	1.0										
+648	periscope	3.0	trade secret	1.0					trade secret	1.0					property	1.0					process information	2							transparency	1.0										
+649	international	3.0	property	1.0					property	1.0					data protection practice	1.0					question comment complaint	2							people	1.0										
+650	compromise	3.0	data protection practice	1.0					data protection practice	1.0					voice	1.0					south	2							ad	1.0										
+651	contractual	3.0	voice	1.0					voice	1.0					support center	1.0					setting page	2							safety setting	1.0										
+652	headspace	3.0	support center	1.0					support center	1.0					data policy	1.0					request contact	2							tweet	1.0										
+653	lane	3.0	data policy	1.0					datum protection authority	1.0					gdprbot	1.0					sns	2							correction deletion	1.0										
+654	itv	3.0	gdprbot	1.0					data policy	1.0					privacy regulator	1.0					facebook account	2							account feature	1.0										
+655	sega	3.0	privacy regulator	1.0					gdprbot	1.0					possession	1.0					future	2							dispute resolution body	1.0										
+656	playdemic	3.0	possession	1.0					privacy regulator	1.0					datum protection regulator	1.0					privacy policy contact	2							complaint resolution process	1.0										
+657	drawer	3.0	datum protection regulator	1.0					possession	1.0					building flat	1.0					eu representative	2							participation	1.0										
+658	keyword	2.0	building flat	1.0					datum protection regulator	1.0					security measure	1.0					agreement	2							arbitration process	1.0										
+659	result	2.0	security measure	1.0					building flat	1.0					ip address	1.0					port	2							right request	1.0										
+660	pre	2.0	ip address	1.0					security measure	1.0					-emailor po box	1.0					open	2							update tool	1.0										
+661	agreement	2.0	-emailor po box	1.0					ip address	1.0					contact email	1.0					game account datum	2							accountability	1.0										
+662	hinderance	2.0	contact email	1.0					-emailor po box	1.0					account security marketing preference app	1.0					word	2							id	1.0										
+663	advertisement	2.0	account security marketing preference app	1.0					contact email	1.0					transparency	1.0					substance	2							deletion function	1.0										
+664	appeal	2.0	transparency	1.0					account security marketing preference app	1.0					people	1.0					datum process	2							privacy question concern	1.0										
+665	remedy	2.0	people	1.0					transparency	1.0					ad	1.0					realization	2							privacy inquiry form	1.0										
+666	wide	2.0	ad	1.0					people	1.0					safety setting	1.0					claim arise	2							touch	1.0										
+667	singapore	2.0	safety setting	1.0					ad	1.0					tweet	1.0					datum breach	2							-emailwith	1.0										
+668	reject	2.0	tweet	1.0					safety setting	1.0					correction deletion	1.0					mention topic	2							information collection	1.0										
+669	enforce	2.0	correction deletion	1.0					tweet	1.0					account feature	1.0					accident occur	2							dissemination practice	1.0										
+670	aspect	2.0	account feature	1.0					correction deletion	1.0					dispute resolution body	1.0					alexadra games	2							support channel	1.0										
+671	bring	2.0	complaint resolution process	1.0					account feature	1.0					complaint resolution process	1.0					following contact information	2							ticket	1.0										
+672	external	2.0	dispute resolution body	1.0					dispute resolution body	1.0					participation	1.0					continue process	2							computer phone	1.0										
+673	fundamental	2.0	arbitration process	1.0					complaint resolution process	1.0					arbitration process	1.0					assistance	2							tablet	1.0										
+674	suspend	2.0	participation	1.0					arbitration process	1.0					right request	1.0					remain	2							organization	1.0										
+675	defend	2.0	right request	1.0					participation	1.0					update tool	1.0					reside work	2							registration profile	1.0										
+676	lift	2.0	update tool	1.0					right request	1.0					accountability	1.0					connect	2							user preference	1.0										
+677	exception	2.0	accountability	1.0					update tool	1.0					id	1.0					automate decision-making include profiling	2							datum collection	1.0										
+678	insofar	2.0	id	1.0					accountability	1.0					deletion function	1.0					datum include information	2							processing practice	1.0										
+679	old	2.0	deletion function	1.0					id	1.0					privacy question concern	1.0					controller confirmation	2							security violation	1.0										
+680	notwithstanding	2.0	privacy question concern	1.0					deletion function	1.0					privacy inquiry form	1.0					supervise	2							-emailor	1.0										
+681	easy	2.0	privacy inquiry form	1.0					privacy question concern	1.0					touch	1.0					state authority	2							storage	1.0										
+682	terminate	2.0	touch	1.0					privacy inquiry form	1.0					amend delete	1.0					rectification deletion	2							-emailany time	1.0										
+683	membership	2.0	amend delete	1.0					touch	1.0					-emailwith	1.0					personal datum infringe	2							software	1.0										
+684	finally	2.0	-emailwith	1.0					amend delete	1.0					information collection	1.0					request removal	2							research activity	1.0										
+685	duration	2.0	dissemination practice	1.0					-emailwith	1.0					dissemination practice	1.0					publish	2							cookie feature	1.0										
+686	oblige	2.0	information collection	1.0					dissemination practice	1.0					support channel	1.0					opposition	2							collection use	1.0										
+687	involve	2.0	support channel	1.0					information collection	1.0					ticket	1.0					mailing list	2							app information	1.0										
+688	newsletter	2.0	ticket	1.0					support channel	1.0					computer phone	1.0					obtain confirmation	2							service e	1.0										
+689	emailso	2.0	computer phone	1.0					ticket	1.0					tablet	1.0					button	2							business relationship	1.0										
+690	violate	2.0	tablet	1.0					computer phone	1.0					organization	1.0					correct update amend	2							information disclosure	1.0										
+691	livu	2.0	organization	1.0					tablet	1.0					registration profile	1.0					california	2							acknowledgement	1.0										
+692	commercially	2.0	user preference	1.0					organization	1.0					user preference	1.0					mailing address	2							datum privacy inquiry	1.0										
+693	scope	2.0	registration profile	1.0					registration profile	1.0					datum collection	1.0					accommodate	2							information request	1.0										
+694	visitor	2.0	security violation	1.0					user preference	1.0					processing practice	1.0					support feature	2							login setting	1.0										
+695	particulary	2.0	datum collection	1.0					security violation	1.0					security violation	1.0					claim regard	2							network	1.0										
+696	testimonial	2.0	processing practice	1.0					processing practice	1.0					-emailor	1.0					information regard	2							user request	1.0										
+697	restore	2.0	-emailor	1.0					datum collection	1.0					storage	1.0					advertising	2							game app	1.0										
+698	instruct	2.0	storage	1.0					-emailor	1.0					-emailany time	1.0					discretion	2							retention obligation	1.0										
+699	800	2.0	-emailany time	1.0					storage	1.0					software	1.0					exemption	2							internet browser	1.0										
+700	1800	2.0	software	1.0					-emailany time	1.0					cookie feature	1.0					time review	2							information society	1.0										
+701	007	2.0	cookie feature	1.0					software	1.0					collection use	1.0					reserve	2							rectification erasure portability	1.0										
+702	metro	2.0	collection use	1.0					cookie feature	1.0					app information	1.0					case edit	2							blocking	1.0										
+703	high	2.0	app information	1.0					collection use	1.0					service e	1.0					file complaint	2							username password email address	1.0										
+704	instal	2.0	service e	1.0					app information	1.0					business relationship	1.0					following information	2							game forum	1.0										
+705	simple	2.0	business relationship	1.0					service e	1.0					information disclosure	1.0					understand	2							controller service	1.0										
+706	mopub	2.0	information disclosure	1.0					business relationship	1.0					acknowledgement	1.0					consent contract	2							datum privacy authority	1.0										
+707	independent	2.0	acknowledgement	1.0					information disclosure	1.0					datum privacy inquiry	1.0					connection	2							rectification update	1.0										
+708	association	2.0	datum privacy inquiry	1.0					acknowledgement	1.0					information request	1.0					origin	2							source	1.0										
+709	efta	2.0	information request	1.0					datum privacy inquiry	1.0					login setting	1.0					automated mean	2							amendment	1.0										
+710	employee	2.0	login setting	1.0					information request	1.0					network	1.0					balance	2							company service	1.0										
+711	gmbh	2.0	network	1.0					login setting	1.0					user request	1.0					user information	2							question query	1.0										
+712	destruction	2.0	game app	1.0					network	1.0					game app	1.0					customer service channel	2							letter e	1.0										
+713	reply	2.0	user request	1.0					user request	1.0					retention obligation	1.0					client	2							sentence	1.0										
+714	france	2.0	retention obligation	1.0					game app	1.0					internet browser	1.0					chat history	2							contact e	1.0										
+715	rue	2.0	internet browser	1.0					retention obligation	1.0					information society	1.0					select	2							portabilityof	1.0										
+716	75010	2.0	information society	1.0					internet browser	1.0					rectification erasure portability	1.0					above-mention	2							data protection authorityabout	1.0										
+717	summary	2.0	rectification erasure portability	1.0					information society	1.0					blocking	1.0					telemarketing	2							data protection issue	1.0										
+718	persoonsgegevens	2.0	blocking	1.0					rectification erasure portability	1.0					username password email address	1.0					endeavour	2							information practice	1.0										
+719	dutch	2.0	username password email address	1.0					blocking	1.0					game forum	1.0					following email address	2							privacy policy change	1.0										
+720	autoriteit	2.0	game forum	1.0					username password email address	1.0					controller service	1.0					play	2							publisher partner	1.0										
+721	promotion	2.0	controller service	1.0					game forum	1.0					datum privacy authority	1.0					follow information	2							account tool	1.0										
+722	supplementary	2.0	datum privacy authority	1.0					controller service	1.0					source	1.0					address set	2							account deletion	1.0										
+723	ad	2.0	rectification update	1.0					datum privacy authority	1.0					rectification update	1.0					privacy shield policy	2							advertising demand portal	1.0										
+724	identifier	2.0	amendment	1.0					rectification update	1.0					amendment	1.0					satisfaction	2							publisher	1.0										
+725	reset	2.0	source	1.0					source	1.0					company service	1.0					acknowledgment	2							companyattn	1.0										
+726	small	2.0	company service	1.0					amendment	1.0					question query	1.0					datum retain	2							account holder	1.0										
+727	join	2.0	question query	1.0					company service	1.0					letter e	1.0					mind	2							s	1.0										
+728	nickname	2.0	letter f	1.0					question query	1.0					sentence	1.0					prefer	2							family plan	1.0										
+729	44th	2.0	sentence	1.0					letter f	1.0					contact e	1.0					information maintain	2							material	1.0										
+730	110	2.0	contact e	1.0					sentence	1.0					processingof	1.0					california civil code section	2							unsubscribe	1.0										
+731	10036	2.0	processingof	1.0					contact e	1.0					portabilityof	1.0					amino	2							agent question comment	1.0										
+732	zone	2.0	portabilityof	1.0					processingof	1.0					data protection authorityabout	1.0					datum associate	2							eea	1.0										
+733	park	2.0	data protection authorityabout	1.0					portabilityof	1.0					data protection issue	1.0					email contain	2							agent	1.0										
+734	tracking	2.0	data protection issue	1.0					data protection authorityabout	1.0					privacy policy change	1.0					prevent misuse	2							suite	1.0										
+735	cancelled	2.0	privacy policy change	1.0					data protection issue	1.0					information practice	1.0					-emailalong	2							ec3r	1.0										
+736	opportunity	2.0	information practice	1.0					privacy policy change	1.0					publisher partner	1.0					passport	2							information society service	1.0										
+737	task	2.0	publisher partner	1.0					information practice	1.0					advertising demand portal	1.0					delete user provide datum	2							part	1.0										
+738	canary	2.0	advertising demand portal	1.0					publisher partner	1.0					account deletion	1.0					access control	2							lawfulness	1.0										
+739	wharf	2.0	account deletion	1.0					advertising demand portal	1.0					publisher	1.0					restrict stop processing	2							user base sale pattern traffic volume	1.0										
+740	colonnade	2.0	publisher	1.0					account deletion	1.0					companyattn	1.0					driver	2							analytic	1.0										
+741	e14	2.0	companyattn	1.0					publisher	1.0					account holder	1.0					complaint relate	2							group company	1.0										
+742	proof	2.0	account holder	1.0					companyattn	1.0					s	1.0					cost	2							company number	1.0										
+743	94104	2.0	family plan	1.0					account holder	1.0					family plan	1.0					accept	2							producer	1.0										
+744	2nd	2.0	unsubscribe	1.0					family plan	1.0					material	1.0					department	2							programme	1.0										
+745	registry	2.0	material	1.0					material	1.0					unsubscribe	1.0					fix	2							ico	1.0										
+746	designate	2.0	agent question comment	1.0					unsubscribe	1.0					agent question comment	1.0					rooster teeth productions llc	2							privacy query	1.0										
+747	tab	2.0	eea	1.0					agent question comment	1.0					eea	1.0					legal department	2							storage deletion	1.0										
+748	valid	2.0	ec3r	1.0					eea	1.0					suite	1.0					request question	2							death	1.0										
+749	contextlogic	2.0	suite	1.0					suite	1.0					ec3r	1.0					user request	2							game support	1.0										
+750	sns	2.0	information society service	1.0					ec3r	1.0					information society service	1.0					saygames	2							policy term	1.0										
+751	war	2.0	part	1.0					information society service	1.0					part	1.0					user license	2							publishing	1.0										
+752	commercial	2.0	lawfulness	1.0					part	1.0					lawfulness	1.0					-url-	2							experience	1.0										
+753	ticket	2.0	user base sale pattern traffic volume	1.0					lawfulness	1.0					user base sale pattern traffic volume	1.0					stay	2							choicesyou	1.0										
+754	open	2.0	analytic	1.0					user base sale pattern traffic volume	1.0					analytic	1.0					belarus minsk	2							platform	1.0										
+755	94103	2.0	group company	1.0					analytic	1.0					group company	1.0					access information	2							marketing use	1.0										
+756	word	2.0	programme	1.0					group company	1.0					producer	1.0					evaluation	2							contactquestion comment	1.0										
+757	clarification	2.0	producer	1.0					producer	1.0					programme	1.0					assessment	2							-emailprivacy	1.0										
+758	realization	2.0	ico	1.0					programme	1.0					ico	1.0					balancing test	2							representative	1.0										
+759	accident	2.0	privacy query	1.0					ico	1.0					privacy query	1.0					access change	2							datum processing activity	1.0										
+760	topic	2.0	storage deletion	1.0					privacy query	1.0					storage deletion	1.0					invoke	2							rightsyou	1.0										
+761	alexadra	2.0	death	1.0					storage deletion	1.0					death	1.0					live work	2							impact	1.0										
+762	overmobile	2.0	policy term	1.0					death	1.0					game support	1.0					deactivation page	2							right -email-	1.0										
+763	connect	2.0	game support	1.0					game support	1.0					policy term	1.0					visit feedback page	2							account detail	1.0										
+764	supervise	2.0	experience	1.0					policy term	1.0					publishing	1.0					attention	2							complaintsin	1.0										
+765	blog	2.0	publishing	1.0					publishing	1.0					experience	1.0					address book contact	2							on	1.0										
+766	publish	2.0	choicesyou	1.0					experience	1.0					choicesyou	1.0					means	2							web site	1.0										
+767	opposition	2.0	marketing use	1.0					choicesyou	1.0					platform	1.0					contact twitter	2							manufacturer	1.0										
+768	amendment	2.0	platform	1.0					platform	1.0					marketing use	1.0					irish data protection commission	2							credit card information	1.0										
+769	301	2.0	contactquestion comment	1.0					marketing use	1.0					contactquestion comment	1.0					principles	2							date information	1.0										
+770	accommodate	2.0	-emailprivacy	1.0					contactquestion comment	1.0					-emailprivacy	1.0					yumobi tekhnolodzhi ooo support service	2							mail notification setting	1.0										
+771	discretion	2.0	datum processing activity	1.0					-emailprivacy	1.0					datum processing activity	1.0					notification	2							click setting	1.0										
+772	alert	2.0	impact	1.0					datum processing activity	1.0					rightsyou	1.0					variation	2							payment setting	1.0										
+773	nicosia	2.0	right -email-	1.0					impact	1.0					right -email-	1.0					depend	2							mail password communication	1.0										
+774	avenue	2.0	account detail	1.0					right -email-	1.0					account detail	1.0					access right	2							gift card balance	1.0										
+775	reserve	2.0	complaintsin	1.0					account detail	1.0					complaintsin	1.0					privacy law	2							advertising preference address book	1.0										
+776	understand	2.0	web site	1.0					complaintsin	1.0					on	1.0					country include	2							gift registry	1.0										
+777	microsoft	2.0	on	1.0					on	1.0					web site	1.0					information relate	2							shopping list	1.0										
+778	care	2.0	manufacturer	1.0					web site	1.0					manufacturer	1.0					data section	2							recommendation	1.0										
+779	family	2.0	credit card information	1.0					manufacturer	1.0					credit card information	1.0					action	2							list reminder	1.0										
+780	later	2.0	advertising preference address book	1.0					credit card information	1.0					date information	1.0					perform	2							seller account	1.0										
+781	thing	2.0	mail notification setting	1.0					mail notification setting	1.0					mail notification setting	1.0					assist	2							certificate	1.0										
+782	trustarc	2.0	date information	1.0					gift card balance	1.0					gift card balance	1.0					review delete	2							product review	1.0										
+783	connection	2.0	gift card balance	1.0					date information	1.0					mail password communication	1.0					follow address	2							wish	1.0										
+784	plan	2.0	mail password communication	1.0					advertising preference address book	1.0					payment setting	1.0					camel games	2							support request	1.0										
+785	obligate	2.0	click setting	1.0					mail password communication	1.0					advertising preference address book	1.0					purpose include	2							system provider	1.0										
+786	client	2.0	list reminder	1.0					click setting	1.0					click setting	1.0					search	2							communication preference	1.0										
+787	chat	2.0	payment setting	1.0					gift registry	1.0					gift registry	1.0					share information	2							information information	1.0										
+788	history	2.0	gift registry	1.0					payment setting	1.0					shopping list	1.0					portion	2							mail preference page	1.0										
+789	telemarketing	2.0	shopping list	1.0					shopping list	1.0					list reminder	1.0					hope	2							unit	1.0										
+790	hear	2.0	product review	1.0					list reminder	1.0					recommendation	1.0					research activity	2							beginning	1.0										
+791	endeavour	2.0	seller account	1.0					product review	1.0					seller account	1.0					transmission	2							party application	1.0										
+792	homer	2.0	recommendation	1.0					seller account	1.0					product review	1.0					residence	2							data access	1.0										
+793	4th	2.0	wish	1.0					recommendation	1.0					certificate	1.0					modify update	2							data retention	1.0										
+794	studio	2.0	certificate	1.0					wish	1.0					wish	1.0					supply	2							support section	1.0										
+795	studios	2.0	support request	1.0					certificate	1.0					support request	1.0					website account	2							country website	1.0										
+796	acknowledgment	2.0	system provider	1.0					support request	1.0					system provider	1.0					bdsg	2							data processing activity	1.0										
+797	satisfaction	2.0	communication preference	1.0					system provider	1.0					communication preference	1.0					datum restrict	2							language website	1.0										
+798	various	2.0	information information	1.0					communication preference	1.0					information information	1.0					processing operation execute	2							location information	1.0										
+799	left	2.0	mail preference page	1.0					information information	1.0					mail preference page	1.0					use art	2							subscription feature	1.0										
+800	prefer	2.0	unit	1.0					mail preference page	1.0					unit	1.0					datum constitute	2							website link	1.0										
+801	musescore	2.0	beginning	1.0					unit	1.0					beginning	1.0					obtain removal	2							data protection right	1.0										
+802	civil	2.0	party application	1.0					beginning	1.0					party application	1.0					contact headspace	2							email phone fax	1.0										
+803	1798	2.0	data access	1.0					party application	1.0					data access	1.0					cookie policy	2							box	1.0										
+804	passport	2.0	data retention	1.0					data access	1.0					data retention	1.0					company number	2							privacy preference	1.0										
+805	emailalong	2.0	support section	1.0					data retention	1.0					support section	1.0					vat registration number	2							minor	1.0										
+806	fast	2.0	country website	1.0					support section	1.0					country website	1.0					homa	2							measure	1.0										
+807	payment	2.0	data processing activity	1.0					country website	1.0					data processing activity	1.0					contact homa games section	2							email sms push notification	1.0										
+808	aggregate	2.0	language website	1.0					data processing activity	1.0					language website	1.0					following right	2							asset	1.0										
+809	fide	2.0	location information	1.0					language website	1.0					location information	1.0					lodge complaint	2							seller	1.0										
+810	bona	2.0	subscription feature	1.0					location information	1.0					subscription feature	1.0					range	2							buyer	1.0										
+811	fix	2.0	website link	1.0					subscription feature	1.0					website link	1.0					fireproof	2							right property	1.0										
+812	rooster	2.0	privacy statement	1.0					website link	1.0					privacy statement	1.0					telephone	2							duty	1.0										
+813	austin	2.0	data protection right	1.0					privacy statement	1.0					data protection right	1.0					sega europe limited customer services	2							issue concern	1.0										
+814	tx	2.0	email phone fax	1.0					data protection right	1.0					email phone fax	1.0					contact form	2							privacy policythis policy	1.0										
+815	51st	2.0	box	1.0					email phone fax	1.0					box	1.0					address telephone number	2							delivery point	1.0										
+816	productions	2.0	privacy preference	1.0					box	1.0					privacy preference	1.0					email address provide	2							parcel	1.0										
+817	1901	2.0	measure	1.0					privacy preference	1.0					minor	1.0					mcdonald	2							pickup service update delivery schedule	1.0										
+818	78723	2.0	minor	1.0					minor	1.0					measure	1.0					apply	2							vacancy owner driver franchise service	1.0										
+819	separately	2.0	email sms push notification	1.0					measure	1.0					email sms push notification	1.0					non-eu national reside	2							cookie policy phishing data protection	1.0										
+820	liability	2.0	right property	1.0					email sms push notification	1.0					asset	1.0					eu citizen	2							technology security career	1.0										
+821	property	2.0	asset	1.0					asset	1.0					right property	1.0					spotify usa inc	2							sitemap fuel surcharge	1.0										
+822	license	2.0	seller	1.0					right property	1.0					seller	1.0					privacy office	2							postcode	1.0										
+823	automatically	2.0	duty	1.0					buyer	1.0					duty	1.0					adapt	1							award	1.0										
+824	concerned	2.0	buyer	1.0					seller	1.0					buyer	1.0					position	1							moment	1.0										
+825	stay	2.0	issue concern	1.0					duty	1.0					issue concern	1.0					email list	1							privacy safeguard	1.0										
+826	internal	2.0	privacy policythis policy	1.0					issue concern	1.0					privacy policythis policy	1.0					agreement base	1							security guideline	1.0										
+827	belarus	2.0	delivery point	1.0					privacy policythis policy	1.0					delivery point	1.0					contract accord	1							certification	1.0										
+828	minsk	2.0	parcel	1.0					delivery point	1.0					parcel	1.0					automate tool	1							region	1.0										
+829	carefully	2.0	pickup service update delivery schedule	1.0					parcel	1.0					pickup service update delivery schedule	1.0					limit data collection	1							download request	1.0										
+830	assessment	2.0	vacancy owner driver franchise service	1.0					pickup service update delivery schedule	1.0					vacancy owner driver franchise service	1.0					govern	1							reply	1.0										
+831	test	2.0	cookie policy phishing data protection	1.0					vacancy owner driver franchise service	1.0					cookie policy phishing data protection	1.0					interest marketing	1							conjunction	1.0										
+832	evaluation	2.0	technology security career	1.0					cookie policy phishing data protection	1.0					technology security career	1.0					research	1							mobile app	1.0										
+833	emailany	2.0	sitemap fuel surcharge	1.0					technology security career	1.0					postcode	1.0					request describe	1							-emailor assistance	1.0										
+834	invoke	2.0	postcode	1.0					sitemap fuel surcharge	1.0					award	1.0					expiration	1							center	1.0										
+835	topface	2.0	award	1.0					postcode	1.0					sitemap fuel surcharge	1.0					retention period	1							sharing preference	1.0										
+836	measure	2.0	moment	1.0					award	1.0					moment	1.0					dedicate section	1							ease	1.0										
+837	solve	2.0	privacy safeguard	1.0					moment	1.0					privacy safeguard	1.0					owner obtain disclosure regard	1							tax audit	1.0										
+838	attention	2.0	security guideline	1.0					privacy safeguard	1.0					security guideline	1.0					data undergo processing	1							accounting obligation	1.0										
+839	book	2.0	certification	1.0					security guideline	1.0					certification	1.0					bring	1							credit	1.0										
+840	serve	2.0	download request	1.0					certification	1.0					download request	1.0					justification	1							fraud prevention	1.0										
+841	safety	2.0	region	1.0					download request	1.0					region	1.0					datum protection officer	1							age limit	1.0										
+842	means	2.0	reply	1.0					region	1.0					reply	1.0					jagex limited	1							control section	1.0										
+843	irish	2.0	conjunction	1.0					reply	1.0					conjunction	1.0					datum protection issue	1							information cookie	1.0										
+844	adherence	2.0	mobile app	1.0					conjunction	1.0					mobile app	1.0					impact	1							note deactivation	1.0										
+845	principles	2.0	-emailor assistance	1.0					mobile app	1.0					-emailor assistance	1.0					data accuracy	1																		
+846	variation	2.0	center	1.0					-emailor assistance	1.0					center	1.0					follow scenario	1																		
+847	depend	2.0	sharing preference	1.0					center	1.0					sharing preference	1.0					deletion obligation	1																		
+848	unsatisfied	2.0	ease	1.0					sharing preference	1.0					ease	1.0					gdpr apply	1																		
+849	active	2.0	tax audit	1.0					ease	1.0					accounting obligation	1.0					user change	1																		
+850	assist	2.0	accounting obligation	1.0					fraud prevention	1.0					tax audit	1.0					duration	1																		
+851	perform	2.0	fraud prevention	1.0					tax audit	1.0					fraud prevention	1.0					termination	1																		
+852	action	2.0	credit	1.0					accounting obligation	1.0					credit	1.0					exclude	1																		
+853	camel	2.0	control section	1.0					credit	1.0					age limit	1.0					user behaviour	1																		
+854	say	2.0	age limit	1.0					age limit	1.0					control section	1.0					addition accord	1																		
+855	sas	2.0	information cookie	1.0					control section	1.0					information cookie	1.0					data transferability	1																		
+856	portion	2.0	note deactivation	1.0					information cookie	1.0					note deactivation	1.0					obstruction provide	1																		
+857	promptly	2.0							note deactivation	1.0											jaumos processing	1																		
+858	hope	2.0																			app setting	1																		
+859	2018	2.0																			-emailor send	1																		
+860	network	2.0																			hold information	1																		
+861	urlto	2.0																			child age	1																		
+862	electronically	2.0																			manage review	1																		
+863	informed	2.0																			delete content	1																		
+864	flaregames	2.0																			cancel	1																		
+865	transmission	2.0																			email request	1																		
+866	exist	2.0																			apps profile page	1																		
+867	supply	2.0																			lingodeer	1																		
+868	centre	2.0																			contact lingodeer	1																		
+869	50	2.0																			registration account	1																		
+870	bdsg	2.0																			delete datum	1																		
+871	35	2.0																			asus	1																		
+872	execute	2.0																			designated countriemay	1																		
+873	constitute	2.0																			want livu	1																		
+874	huuuges	2.0																			choose exit	1																		
+875	huuuge	2.0																			datum protection law	1																		
+876	suite	2.0																			portal	1																		
+877	emailin	2.0																			datum protection regulation	1																		
+878	vat	2.0																			reason arise	1																		
+879	w1t	2.0																			e-mail address provide	1																		
+880	0041	2.0																			datum process concern	1																		
+881	76	2.0																			pursuant	1																		
+882	tiktok	2.0																			email preference	1																		
+883	broad	2.0																			unsubscribe link find	1																		
+884	range	2.0																			discontinue receive	1																		
+885	seller	2.0																			member profile	1																		
+886	house	2.0																			forum account	1																		
+887	england	2.0																			support account	1																		
+888	properly	2.0																			customer support team	1																		
+889	fireproof	2.0																			feedback	1																		
+890	brentford	2.0																			users datum	1																		
+891	845	2.0																			permission	1																		
+892	5502	2.0																			support widget	1																		
+893	14	2.0																			expression	1																		
+894	mcdonald	2.0																			evidence	1																		
+895	freeview	2.0																			follow reason apply	1																		
+896	3jf	2.0																			ight	1																		
+897	mortimer	2.0																			authoriy	1																		
+898	sell	2.0																			accept cookie	1																		
+899	picsart	2.0																			related entity	1																		
+900	publicly	2.0																			privacy laws	1																		
+901	dpdgroup	2.0																			exemption provide	1																		
+902	b66	2.0																			metro	1																		
+903	governance	2.0																			seek access	1																		
+904	management	2.0																			metro department	1																		
+905	grci	2.0																			metros privacy officer	1																		
+906	lagavooren	2.0																			incur	1																		
+907	boyne	2.0																			mobile	1																		
+908	citizen	2.0																			pay phone	1																		
+909	netflix	2.0																			metro customer service number	1																		
+910	position	1.0																			require change	1																		
+911	adapt	1.0																			mobisystems inc	1																		
+912	suntec	1.0																			instal	1																		
+913	038988	1.0																			activity	1																		
+914	temasek	1.0																			google analytics opt-out browser add-on	1																		
+915	08	1.0																			flurry analytics service	1																		
+916	05	1.0																			prevent flurry analytics	1																		
+917	boulevard	1.0																			flurry	1																		
+918	govern	1.0																			principle	1																		
+919	expiration	1.0																			oblige	1																		
+920	dedicate	1.0																			condition set	1																		
+921	justification	1.0																			dot	1																		
+922	oversee	1.0																			com	1																		
+923	jagex	1.0																			mopubs personalized advertising experience	1																		
+924	successfully	1.0																			mopub partners	1																		
+925	impact	1.0																			contact twitters data protection officer	1																		
+926	scenario	1.0																			suggestion concern data protection	1																		
+927	irreversibly	1.0																			datum specify	1																		
+928	termination	1.0																			data stock	1																		
+929	exclude	1.0																			register person	1																		
+930	statistical	1.0																			indication	1																		
+931	behaviour	1.0																			storage obligation	1																		
+932	irrespective	1.0																			consent issue	1																		
+933	19	1.0																			declaration	1																		
+934	disproportionate	1.0																			time entitle	1																		
+935	transferability	1.0																			controller rectification	1																		
+936	obstruction	1.0																			data subject wish	1																		
+937	jaumos	1.0																			following apply	1																		
+938	entirely	1.0																			carly solutions gmbh co kg	1																		
+939	kindly	1.0																			possibility	1																		
+940	apps	1.0																			paypal	1																		
+941	asus	1.0																			set so-call opt-out cookie	1																		
+942	countriemay	1.0																			digital advertising alliances website use	1																		
+943	designated	1.0																			option state	1																		
+944	exit	1.0																			europe	1																		
+945	vis	1.0																			contact information provide	1																		
+946	discontinue	1.0																			retention period use	1																		
+947	navigate	1.0																			prevent recovery	1																		
+948	3979	1.0																			destruction process	1																		
+949	clara	1.0																			contact information offer	1																		
+950	santa	1.0																			data manager contact information section	1																		
+951	95054	1.0																			reply	1																		
+952	circle	1.0																			submit datum use	1																		
+953	12th	1.0																			flow	1																		
+954	users	1.0																			disconnect	1																		
+955	widget	1.0																			application setting menu	1																		
+956	evidence	1.0																			service feel	1																		
+957	expression	1.0																			upload	1																		
+958	lastly	1.0																			find contact detail	1																		
+959	ight	1.0																			-emailor send mail	1																		
+960	authoriy	1.0																			registration information	1																		
+961	laws	1.0																			r2games	1																		
+962	metros	1.0																			power	1																		
+963	992	1.0																			modify change update	1																		
+964	1300	1.0																			rules	1																		
+965	pay	1.0																			following link	1																		
+966	363	1.0																			relive	1																		
+967	incur	1.0																			detail change	1																		
+968	mobisystems	1.0																			information appear	1																		
+969	having	1.0																			dutch supervisory authority autoriteit persoonsgegevens	1																		
+970	flurry	1.0																			help page	1																		
+971	principle	1.0																			data protection officer know	1																		
+972	adopt	1.0																			skg	1																		
+973	interested	1.0																			case request information	1																		
+974	mondly	1.0																			estriction	1																		
+975	com	1.0																			datum want	1																		
+976	dot	1.0																			storytel process	1																		
+977	mopubs	1.0																			contradiction	1																		
+978	partners	1.0																			data protection legislation	1																		
+979	twitters	1.0																			personal data protection commission	1																		
+980	stock	1.0																			marketing advertising	1																		
+981	indication	1.0																			promotion purpose	1																		
+982	declaration	1.0																			advertising purpose	1																		
+983	separate	1.0																			behalf	1																		
+984	double	1.0																			receive confirmation	1																		
+985	carly	1.0																			realize	1																		
+986	solutions	1.0																			uninstall	1																		
+987	kg	1.0																			doubt	1																		
+988	paypal	1.0																			device ad identifier	1																		
+989	possibility	1.0																			interest base advertising	1																		
+990	alliances	1.0																			merchandise relate	1																		
+991	apart	1.0																			remove information	1																		
+992	recovery	1.0																			marketing preference	1																		
+993	past	1.0																			customer service department	1																		
+994	manager	1.0																			social club	1																		
+995	primarily	1.0																			email -emailfrom	1																		
+996	petites	1.0																			email account	1																		
+997	ecuries	1.0																			join social club include	1																		
+998	des	1.0																			social club nickname	1																		
+999	disconnect	1.0																			field	1																		
+1000	flow	1.0																			social point hold	1																		
+1001	r2games	1.0																			social point mailing list	1																		
+1002	power	1.0																			delete restrict	1																		
+1003	rules	1.0																			646-536-2842	1																		
+1004	relive	1.0																			download edit	1																		
+1005	irrelevant	1.0																			prof	1																		
+1006	appear	1.0																			edit hide	1																		
+1007	grave	1.0																			tandem app	1																		
+1008	skg	1.0																			tandems customer support	1																		
+1009	youd	1.0																			use tandem	1																		
+1010	final	1.0																			complaint erasure	1																		
+1011	0161	1.0																			access rectification	1																		
+1012	1162	1.0																			blockage	1																		
+1013	768	1.0																			tandem user	1																		
+1014	estriction	1.0																			storage purpose	1																		
+1015	storytel	1.0																			-phoneor	1																		
+1016	contradiction	1.0																			zone chengdu sichuan china	1																		
+1017	behalf	1.0																			endeavor	1																		
+1018	realize	1.0																			operating system setting	1																		
+1019	uninstall	1.0																			identifier	1																		
+1020	doubt	1.0																			decline cookie	1																		
+1021	merchandise	1.0																			ted	1																		
+1022	2k	1.0																			ted sites	1																		
+1023	club	1.0																			contact ted	1																		
+1024	emailfrom	1.0																			information collect process use	1																		
+1025	field	1.0																			tile device	1																		
+1026	2842	1.0																			supplement cancelled update	1																		
+1027	536	1.0																			instruction provide	1																		
+1028	646	1.0																			task carry	1																		
+1029	regular	1.0																			privacy team	1																		
+1030	eprivacy	1.0																			privacy team thomson reuters	1																		
+1031	represent	1.0																			escalate	1																		
+1032	prof	1.0																			data protection officer thomson reuters	1																		
+1033	hide	1.0																			thomson reuters manage	1																		
+1034	tandems	1.0																			account setting page	1																		
+1035	dont	1.0																			provide proof	1																		
+1036	blockage	1.0																			twitch services	1																		
+1037	common	1.0																			bush street	1																		
+1038	mechanically	1.0																			information ask	1																		
+1039	whilst	1.0																			vertigo games sepapaja	1																		
+1040	tap4fun	1.0																			tallinn	1																		
+1041	tianfu	1.0																			estonia registry code	1																		
+1042	chengdu	1.0																			designate agent	1																		
+1043	sichuan	1.0																			receive email	1																		
+1044	china	1.0																			promotion	1																		
+1045	emailvia	1.0																			device location	1																		
+1046	tech	1.0																			location sharing	1																		
+1047	phoneor	1.0																			turn	1																		
+1048	0086	1.0																			device privacy setting	1																		
+1049	a3	1.0																			device change	1																		
+1050	endeavor	1.0																			share location	1																		
+1051	operating	1.0																			review information associate	1																		
+1052	ted	1.0																			tab	1																		
+1053	sites	1.0																			raise question	1																		
+1054	tile	1.0																			datum use practice	1																		
+1055	2121	1.0																			email address list	1																		
+1056	mateo	1.0																			netherlands data authority	1																		
+1057	94403	1.0																			section contact	1																		
+1058	camino	1.0																			mobile war receive	1																		
+1059	900	1.0																			mobile war	1																		
+1060	transformation	1.0																			place delete	1																		
+1061	restricted	1.0																			account include disassociate	1																		
+1062	escalate	1.0																			progress	1																		
+1063	5ep	1.0																			item	1																		
+1064	twitch	1.0																			review change	1																		
+1065	bush	1.0																			information mobile war	1																		
+1066	350	1.0																			obligation resolve dispute	1																		
+1067	similarly	1.0																			business interest	1																		
+1068	14340159	1.0																			site service application	1																		
+1069	vertigo	1.0																			employ	1																		
+1070	15551	1.0																			technologies	1																		
+1071	estonia	1.0																			block delete	1																		
+1072	tallinn	1.0																			device permit	1																		
+1073	sepapaja	1.0																			processing describe	1																		
+1074	special	1.0																			object apply	1																		
+1075	turn	1.0																			games	1																		
+1076	disassociate	1.0																			-emailto request access	1																		
+1077	lose	1.0																			support ticket	1																		
+1078	virtual	1.0																			seek rectification	1																		
+1079	progress	1.0																			zuuks games	1																		
+1080	item	1.0																			contact zuuks games	1																		
+1081	unused	1.0																			data request portal	1																		
+1082	employ	1.0																			information object	1																		
+1083	zynga	1.0																			personal data request portal	1																		
+1084	699	1.0																			link send e-mail	1																		
+1085	8th	1.0																			contact zynga	1																		
+1086	physical	1.0																			customer support page	1																		
+1087	processor	1.0																			processor	1																		
+1088	frequently	1.0																			request concern	1																		
+1089	musixmatch	1.0																			clarification musixmatch	1																		
+1090	investigation	1.0																			provide e-mail	1																		
+1091	determine	1.0																			competent authority	1																		
+1092	substance	1.0																			correction addition	1																		
+1093	undertake	1.0																			customer request	1																		
+1094	receipt	1.0																			investigation	1																		
+1095	quote	1.0																			personal information protection act	1																		
+1096	effectively	1.0																			achieve	1																		
+1097	just	1.0																			contact support	1																		
+1098	zacna	1.0																			change restrict limit	1																		
+1099	poland	1.0																			interest explain	1																		
+1100	gdask	1.0																			overmobile	1																		
+1101	283	1.0																			overmobile undertake processing	1																		
+1102	80	1.0																			task	1																		
+1103	traditional	1.0																			continue processing	1																		
+1104	remember	1.0																			receipt	1																		
+1105	justified	1.0																			zacna	1																		
+1106	unanswered	1.0																			street	1																		
+1107	thereof	1.0																			gdask poland	1																		
+1108	camsurf	1.0																			remember	1																		
+1109	carx	1.0																			request rectification	1																		
+1110	program	1.0																			justified case	1																		
+1111	mi	1.0																			app section manage	1																		
+1112	updating	1.0																			select remove datum	1																		
+1113	yo	1.0																			communication feature	1																		
+1114	juvenile	1.0																			contact camsurf	1																		
+1115	define	1.0																			decision base	1																		
+1116	mistake	1.0																			process include profiling	1																		
+1117	successful	1.0																			carx technologies limited	1																		
+1118	pending	1.0																			writing use	1																		
+1119	ported	1.0																			collection use disclosure	1																		
+1120	outweigh	1.0																			provide example	1																		
+1121	applier	1.0																			mi account	1																		
+1122	bluehole	1.0																			access updating	1																		
+1123	pnix	1.0																			juvenile	1																		
+1124	acquisition	1.0																			define	1																		
+1125	canada	1.0																			require age	1																		
+1126	rica	1.0																			file erasure	1																		
+1127	hey	1.0																			decision making	1																		
+1128	button	1.0																			datum datum portability	1																		
+1129	circumstancesfor	1.0																			datum objection	1																		
+1130	discord	1.0																			require restriction	1																		
+1131	lockhart	1.0																			mistake	1																		
+1132	chai	1.0																			data rectification	1																		
+1133	wan	1.0																			pending	1																		
+1134	ro	1.0																			freedom outweigh	1																		
+1135	rm	1.0																			policy include request	1																		
+1136	307	1.0																			exercise datum subject	1																		
+1137	19c	1.0																			issue arise	1																		
+1138	ctr	1.0																			national datum protection	1																		
+1139	clicktouch	1.0																			forum	1																		
+1140	abide	1.0																			blog	1																		
+1141	dvapps	1.0																			member information page	1																		
+1142	dvloper	1.0																			communication option update	1																		
+1143	ab	1.0																			collect use	1																		
+1144	easybrain	1.0																			follow applier	1																		
+1145	limassol	1.0																			include base	1																		
+1146	4103	1.0																			gdpr article	1																		
+1147	oval	1.0																			acquisition processing restriction	1																		
+1148	krinou	1.0																			correction update amendment	1																		
+1149	6th	1.0																			data access request	1																		
+1150	emailhowever	1.0																			datum request	1																		
+1151	redirect	1.0																			circumstancesfor example	1																		
+1152	preferred	1.0																			discord offer	1																		
+1153	physically	1.0																			instruction contain	1																		
+1154	document	1.0																			update datum	1																		
+1155	technopark	1.0																			correct change update	1																		
+1156	stakhanovskaya	1.0																			customer service email address	1																		
+1157	perm	1.0																			think clicktouch games	1																		
+1158	54	1.0																			abide	1																		
+1159	findnow	1.0																			post privacy policy	1																		
+1160	renew	1.0																			dvloper	1																		
+1161	invalid	1.0																			dvapps ab	1																		
+1162	iv	1.0																			oval	1																		
+1163	viii	1.0																			krinou street	1																		
+1164	vii	1.0																			easybrain ltd	1																		
+1165	strovolos	1.0																			limassol cyprus	1																		
+1166	petousis	1.0																			redirect	1																		
+1167	146	1.0																			document feel	1																		
+1168	148	1.0																			stakhanovskaya	1																		
+1169	2048	1.0																			technopark perm	1																		
+1170	justify	1.0																			collect regard	1																		
+1171	clearly	1.0																			cancel permission	1																		
+1172	filter	1.0																			account information update	1																		
+1173	communicate	1.0																			question regard view	1																		
+1174	realise	1.0																			findnow	1																		
+1175	sevilla	1.0																			renew	1																		
+1176	spain	1.0																			findnow relate	1																		
+1177	genera	1.0																			alert	1																		
+1178	cardenal	1.0																			information erase	1																		
+1179	planta	1.0																			viii	1																		
+1180	monreal	1.0																			vii	1																		
+1181	bueno	1.0																			data protection regulator	1																		
+1182	41010	1.0																			request relate	1																		
+1183	geozilla	1.0																			146-148 strovolos avenue petousis building	1																		
+1184	especially	1.0																			strovolos nicosia cyprus	1																		
+1185	meaning	1.0																			commissioner	1																		
+1186	significantly	1.0																			personal data protection	1																		
+1187	produce	1.0																			justify	1																		
+1188	chief	1.0																			reason relate	1																		
+1189	healthvault	1.0																			correct datum	1																		
+1190	health	1.0																			specify	1																		
+1191	caregiver	1.0																			proof	1																		
+1192	instagram	1.0																			state ground	1																		
+1193	recover	1.0																			message include	1																		
+1194	status	1.0																			filter	1																		
+1195	3995	1.0																			information communicate	1																		
+1196	82	1.0																			realise	1																		
+1197	1588	1.0																			planta	1																		
+1198	netmarble	1.0																			sevilla	1																		
+1199	yazio	1.0																			sevilla spain	1																		
+1200	compilation	1.0																			geozilla app	1																		
+1201	naturally	1.0																			user content	1																		
+1202	balance	1.0																			eu resident	1																		
+1203	disagree	1.0																			follow case	1																		
+1204	total	1.0																			interest include profiling	1																		
+1205	inquire	1.0																			datum infringe	1																		
+1206	outlet	1.0																			information ask question	1																		
+1207	banking	1.0																			meaning	1																		
+1208	institution	1.0																			privacy policy access	1																		
+1209	overseas	1.0																			include profiling	1																		
+1210	bank	1.0																			produce	1																		
+1211	come	1.0																			automate processing	1																		
+1212	watchdog	1.0																			eu data protection officer	1																		
+1213	keeper	1.0																			microsoft chief privacy officer	1																		
+1214	emailclearly	1.0																			privacy concern complaint	1																		
+1215	ape	1.0																			store health datum	1																		
+1216	thinking	1.0																			gather edit add	1																		
+1217	entertainment	1.0																			family caregiver	1																		
+1218	retrieve	1.0																			healthvault service let	1																		
+1219	authorize	1.0																			health datum	1																		
+1220	planb	1.0																			health care	1																		
+1221	labs	1.0																			facebook setting	1																		
+1222	emailuse	1.0																			instagram setting	1																		
+1223	learning	1.0																			access rectify port	1																		
+1224	factual	1.0																			status update	1																		
+1225	official	1.0																			delete thing	1																		
+1226	460	1.0																			recover	1																		
+1227	10016	1.0																			trustarc	1																		
+1228	south	1.0																			resolve dispute	1																		
+1229	letsvpn	1.0																			contact trustarc	1																		
+1230	level	1.0																			customer center	1																		
+1231	lima	1.0																			customer support menu	1																		
+1232	sky	1.0																			telephone number	1																		
+1233	opinion	1.0																			request email	1																		
+1234	exceptional	1.0																			netmarble	1																		
+1235	signature	1.0																			privacy protection department	1																		
+1236	job	1.0																			contact netmarble	1																		
+1237	consult	1.0																			time information regard	1																		
+1238	forward	1.0																			yazio	1																		
+1239	customize	1.0																			plan duration	1																		
+1240	dedicated	1.0																			compilation	1																		
+1241	advertiser	1.0																			user profile	1																		
+1242	mind	1.0																			data concern	1																		
+1243	belgium	1.0																			data transfer tool	1																		
+1244	octaaf	1.0																			disagree	1																		
+1245	soudanstraat	1.0																			eu local representative	1																		
+1246	denijs	1.0																			inquire	1																		
+1247	9051	1.0																			use icbc business service	1																		
+1248	22	1.0																			icbc outlet	1																		
+1249	westrem	1.0																			area	1																		
+1250	sint	1.0																			icbc mobile banking	1																		
+1251	83	1.0																			user information policy	1																		
+1252	timeline	1.0																			bank	1																		
+1253	outline	1.0																			icbc	1																		
+1254	ur	1.0																			institution	1																		
+1255	nova	1.0																			edit update	1																		
+1256	geims	1.0																			chat history store	1																		
+1257	supervisor	1.0																			rectification erasure	1																		
+1258	remind	1.0																			mention	1																		
+1259	urland	1.0																			come	1																		
+1260	outfit7	1.0																			keeper security account	1																		
+1261	substantiate	1.0																			customer support	1																		
+1262	guarantee	1.0																			privacy policy email	1																		
+1263	berlin	1.0																			thinking ape entertainment ltd	1																		
+1264	berliner	1.0																			retrieve	1																		
+1265	informationsfreiheit	1.0																			datum protection authority	1																		
+1266	datenschutz	1.0																			privacy practice include	1																		
+1267	und	1.0																			hear	1																		
+1268	beauftragte	1.0																			planb labs	1																		
+1269	fr	1.0																			stop collect	1																		
+1270	kwalee	1.0																			child user	1																		
+1271	affiliate	1.0																			child correct	1																		
+1272	requests	1.0																			contact homer learning	1																		
+1273	rider	1.0																			-emailor write	1																		
+1274	making	1.0																			homer	1																		
+1275	hong	1.0																			park avenue south	1																		
+1276	kong	1.0																			floor ny ny	1																		
+1277	israel	1.0																			amsterdam	1																		
+1278	515059236	1.0																			-urlor	1																		
+1279	rosh	1.0																			case access	1																		
+1280	ayin	1.0																			include confirmation	1																		
+1281	industrial	1.0																			personal datum undergo processing	1																		
+1282	ha	1.0																			personal data processing	1																		
+1283	submission	1.0																			datum rectify	1																		
+1284	reque	1.0																			personal datum erase	1																		
+1285	preserve	1.0																			contract performance sin accordance	1																		
+1286	court	1.0																			remove account information	1																		
+1287	reasonably	1.0																			question complaint	1																		
+1288	vary	1.0																			contact level	1																		
+1289	disclaim	1.0																			contact lima sky	1																		
+1290	indefinitely	1.0																			contact lion	1																		
+1291	secret	1.0																			contact lion studio	1																		
+1292	trade	1.0																			lion hold	1																		
+1293	intellectual	1.0																			contact lion studios	1																		
+1294	diandian	1.0																			suggestion concern	1																		
+1295	voice	1.0																			question opinion	1																		
+1296	love	1.0																			circumstance provide	1																		
+1297	connected	1.0																			nickname profile photo signature job	1																		
+1298	adhere	1.0																			address information interest question	1																		
+1299	practically	1.0																			profile-if	1																		
+1300	internatsionalnaya	1.0																			profile photo	1																		
+1301	masha	1.0																			information process	1																		
+1302	republic	1.0																			left	1																		
+1303	220030	1.0																			setting-feedback	1																		
+1304	swag	1.0																			consult	1																		
+1305	str	1.0																			forward	1																		
+1306	terms	1.0																			welcome feedback	1																		
+1307	rightful	1.0																			medium account medium delete	1																		
+1308	30188	1.0																			interest page	1																		
+1309	woodstock	1.0																			customize	1																		
+1310	302	1.0																			correct information associate	1																		
+1311	aurora	1.0																			process contact	1																		
+1312	ga	1.0																			medium	1																		
+1313	ave	1.0																			eu law	1																		
+1314	tastypill	1.0																			following address	1																		
+1315	telegram	1.0																			data controller section	1																		
+1316	proceed	1.0																			datum privacy practice	1																		
+1317	gdprbot	1.0																			advertiser	1																		
+1318	testfoni	1.0																			partner	1																		
+1319	nhn	1.0																			access review update	1																		
+1320	possession	1.0																			profile tab	1																		
+1321	authorized	1.0																			use musescore	1																		
+1322	flat	1.0																			sint-denijs-westrem	1																		
+1323	main	1.0																			octaaf soudanstraat	1																		
+1324	1060	1.0																			belgium	1																		
+1325	40	1.0																			musescore	1																		
+1326	boubolina	1.0																			prevent disclosure	1																		
+1327	ip	1.0																			personal data access	1																		
+1328	track	1.0																			data retention timeline outline	1																		
+1329	sunnyvale	1.0																			request assistance	1																		
+1330	94088	1.0																			data protection regulation provide	1																		
+1331	60429	1.0																			ur contact information	1																		
+1332	po	1.0																			ground provide	1																		
+1333	box	1.0																			ask nova geims ooo	1																		
+1334	rights	1.0																			request limitation	1																		
+1335	tubi	1.0																			regulation	1																		
+1336	montgomery	1.0																			age specify	1																		
+1337	315	1.0																			remind	1																		
+1338	transparency	1.0																			european data protection supervisor	1																		
+1339	discoverable	1.0																			party information collection	1																		
+1340	people	1.0																			party information disclosure	1																		
+1341	tweet	1.0																			delete information provide	1																		
+1342	arbitration	1.0																			deletion request regard	1																		
+1343	participation	1.0																			access correction	1																		
+1344	jams	1.0																			outfit7	1																		
+1345	empower	1.0																			information processing	1																		
+1346	accountability	1.0																			structured	1																		
+1347	gain	1.0																			security question	1																		
+1348	inaccurately	1.0																			resolve complaint	1																		
+1349	treat	1.0																			complaint contact	1																		
+1350	don	1.0																			account profile	1																		
+1351	likewise	1.0																			personal information provide	1																		
+1352	adobe	1.0																			privacy policy notice	1																		
+1353	touch	1.0																			enquiry regard	1																		
+1354	misleading	1.0																			support menu	1																		
+1355	alleged	1.0																			eu law base	1																		
+1356	attempt	1.0																			guarantee	1																		
+1357	identifying	1.0																			gdpr include profiling base	1																		
+1358	dissemination	1.0																			right set	1																		
+1359	applications	1.0																			act accord	1																		
+1360	neptune	1.0																			berlin	1																		
+1361	tablet	1.0																			datenschutz und informationsfreiheit email	1																		
+1362	computer	1.0																			berliner beauftragte	1																		
+1363	instead	1.0																			kwalee	1																		
+1364	browse	1.0																			affiliate	1																		
+1365	tap	1.0																			uber collect	1																		
+1366	search	1.0																			uber require	1																		
+1367	scroll	1.0																			delivery recipient	1																		
+1368	organization	1.0																			rider	1																		
+1369	ellation	1.0																			requests deletion	1																		
+1370	market	1.0																			privacy settings menu	1																		
+1371	835	1.0																			delivery partner	1																		
+1372	cube	1.0																			marketing purpose base	1																		
+1373	dashlane	1.0																			datum include	1																		
+1374	75018	1.0																			automate decision making	1																		
+1375	pierre	1.0																			autoriteit persoonsgegevens	1																		
+1376	picard	1.0																			dutch data protection authority	1																		
+1377	equivalent	1.0																			information uber	1																		
+1378	edpb	1.0																			setting menu	1																		
+1379	adequately	1.0																			email address associate	1																		
+1380	members_en	1.0																			hong kong law	1																		
+1381	board	1.0																			legal protection	1																		
+1382	25	1.0																			registered office	1																		
+1383	longyuan	1.0																			datum information	1																		
+1384	volunteer	1.0																			include access	1																		
+1385	deny	1.0																			datum rectification	1																		
+1386	android	1.0																			submission	1																		
+1387	ios	1.0																			transfer datum	1																		
+1388	behavioral	1.0																			store use	1																		
+1389	essential	1.0																			payment information	1																		
+1390	relationship	1.0																			number	1																		
+1391	precede	1.0																			reque access	1																		
+1392	acknowledgement	1.0																			access read preserve	1																		
+1393	bbb	1.0																			court order	1																		
+1394	exchange	1.0																			vary base	1																		
+1395	12	1.0																			-url- user	1																		
+1396	stipulate	1.0																			contain	1																		
+1397	prior	1.0																			disclaim	1																		
+1398	society	1.0																			liability arise	1																		
+1399	popular	1.0																			related	1																		
+1400	556895	1.0																			destruction	1																		
+1401	1213	1.0																			property	1																		
+1402	brunnsgatan	1.0																			trade secret	1																		
+1403	stockholm	1.0																			data protection practice	1																		
+1404	sweden	1.0																			diandian	1																		
+1405	111	1.0																			love hear	1																		
+1406	38	1.0																			voice	1																		
+1407	blocking	1.0																			microsoft welcome	1																		
+1408	discuss	1.0																			adhere	1																		
+1409	normally	1.0																			privacy feedback	1																		
+1410	brief	1.0																			game id	1																		
+1411	gamegos	1.0																			data transfer	1																		
+1412	express	1.0																			limited liability company swag masha	1																		
+1413	gametion	1.0																			republic	1																		
+1414	pvt	1.0																			internatsionalnaya str	1																		
+1415	username	1.0																			service remain	1																		
+1416	emailbut	1.0																			-emailany time	1																		
+1417	liverpool	1.0																			aurora ave woodstock ga	1																		
+1418	797	1.0																			national datum protection authority regard	1																		
+1419	6340	1.0																			telegram account	1																		
+1420	7pr	1.0																			proceed	1																		
+1421	203	1.0																			data policy	1																		
+1422	ec2m	1.0																			gdprbot	1																		
+1423	portable	1.0																			privacy regulator	1																		
+1424	gogogame	1.0																			testfoni	1																		
+1425	source	1.0																			information apply	1																		
+1426	shepherds	1.0																			nhn	1																		
+1427	catch	1.0																			possession	1																		
+1428	w14	1.0																			datum topface send	1																		
+1429	0ee	1.0																			datum protection regulator	1																		
+1430	java	1.0																			information commissioners	1																		
+1431	sentence	1.0																			boubolina building	1																		
+1432	beechavenue	1.0																			nicosia cyprus	1																		
+1433	rijk	1.0																			topface	1																		
+1434	schiphol	1.0																			data hold	1																		
+1435	1119	1.0																			provider	1																		
+1436	182	1.0																			security measure	1																		
+1437	grab	1.0																			track	1																		
+1438	accessor	1.0																			ip address	1																		
+1439	applicationsor	1.0																			help solve	1																		
+1440	corrector	1.0																			-emailor po box	1																		
+1441	processingof	1.0																			california privacy rights	1																		
+1442	portabilityof	1.0																			privacy tubi inc	1																		
+1443	authorityabout	1.0																			account security marketing preference app	1																		
+1444	polish	1.0																			ve upload	1																		
+1445	cthe	1.0																			control thing	1																		
+1446	president	1.0																			transparency	1																		
+1447	ofdata	1.0																			periscope account	1																		
+1448	huuugegroup	1.0																			periscope setting	1																		
+1449	sp	1.0																			people	1																		
+1450	reflect	1.0																			ve send	1																		
+1451	companyattn	1.0																			serve	1																		
+1452	inquiry1355	1.0																			safety setting let	1																		
+1453	streetdublin	1.0																			object restrict	1																		
+1454	ireland	1.0																			register	1																		
+1455	officerone	1.0																			associate	1																		
+1456	d02	1.0																			account information include	1																		
+1457	companys	1.0																			tweet	1																		
+1458	subsidiary	1.0																			request correction deletion	1																		
+1459	primary	1.0																			periscope	1																		
+1460	holder	1.0																			twitter account	1																		
+1461	material	1.0																			account feature	1																		
+1462	855	1.0																			twitter provide	1																		
+1463	432	1.0																			periscope provide	1																		
+1464	3822	1.0																			twitter inc	1																		
+1465	tricor	1.0																			privacy shield-relate complaint	1																		
+1466	ec3r	1.0																			privacy shield	1																		
+1467	7qr	1.0																			participation	1																		
+1468	mark	1.0																			adherence	1																		
+1469	envisage	1.0																			complaint resolution process	1																		
+1470	lawfulness	1.0																			dispute resolution body jams	1																		
+1471	ul	1.0																			privacy shield arbitration process	1																		
+1472	platonova	1.0																			update tool	1																		
+1473	20b	1.0																			accountability	1																		
+1474	112	1.0																			compromise	1																		
+1475	traffic	1.0																			gain access	1																		
+1476	sale	1.0																			correct information	1																		
+1477	britbox	1.0																			example believe	1																		
+1478	addressable	1.0																			solve	1																		
+1479	group	1.0																			treat	1																		
+1480	emailmake	1.0																			service wish	1																		
+1481	clear	1.0																			review information collect	1																		
+1482	britain	1.0																			information modify	1																		
+1483	programme	1.0																			app allow	1																		
+1484	producer	1.0																			delete file	1																		
+1485	media	1.0																			deletion function	1																		
+1486	06633451	1.0																			fill	1																		
+1487	consumer	1.0																			privacy question concern	1																		
+1488	factor	1.0																			privacy inquiry form	1																		
+1489	ec1n	1.0																			adobe	1																		
+1490	197	1.0																			touch	1																		
+1491	67	1.0																			amend delete	1																		
+1492	hydrane	1.0																			information handle	1																		
+1493	faubourg	1.0																			disclose information	1																		
+1494	death	1.0																			identifying information	1																		
+1495	publishing	1.0																			email include	1																		
+1496	companyabout	1.0																			dissemination practice	1																		
+1497	01	1.0																			site applications	1																		
+1498	choicesyou	1.0																			studio	1																		
+1499	residentsonce	1.0																			neptune	1																		
+1500	calendar	1.0																			review delete change	1																		
+1501	recommend	1.0																			contact neptune	1																		
+1502	contactquestion	1.0																			ticket	1																		
+1503	city	1.0																			support channel	1																		
+1504	usaemail	1.0																			obligate	1																		
+1505	venice	1.0																			review access amend	1																		
+1506	emailprivacy	1.0																			information remove	1																		
+1507	10100	1.0																			information include	1																		
+1508	2019welcome	1.0																			computer phone	1																		
+1509	blvd	1.0																			tablet	1																		
+1510	bytedance	1.0																			app store	1																		
+1511	aviation	1.0																			google play	1																		
+1512	summarywhat	1.0																			browse	1																		
+1513	wc2b	1.0																			tap	1																		
+1514	standard	1.0																			scroll	1																		
+1515	rightsyou	1.0																			contact information list	1																		
+1516	authorise	1.0																			organization	1																		
+1517	proper	1.0																			exercise choice	1																		
+1518	examine	1.0																			follow mailing address	1																		
+1519	complaintsin	1.0																			market st	1																		
+1520	ironhide	1.0																			registration profile	1																		
+1521	flash	1.0																			user preference associate	1																		
+1522	manufacturer	1.0																			data cube software collect	1																		
+1523	reference	1.0																			good	1																		
+1524	thorough	1.0																			dashlane sas	1																		
+1525	availability	1.0																			rue pierre picard	1																		
+1526	shopping	1.0																			need assistance	1																		
+1527	recommendations	1.0																			security violation	1																		
+1528	recommended	1.0																			datum collection	1																		
+1529	recommendation	1.0																			processing practice	1																		
+1530	hays	1.0																			complaint bring	1																		
+1531	guildford	1.0																			edpb	1																		
+1532	surrey	1.0																			board	1																		
+1533	millmead	1.0																			restriction apply	1																		
+1534	north	1.0																			storage	1																		
+1535	wing	1.0																			-urlor -emailany time	1																		
+1536	gu2	1.0																			software	1																		
+1537	4hj	1.0																			longyuan network	1																		
+1538	06687549	1.0																			-emailto	1																		
+1539	interoperable	1.0																			volunteer	1																		
+1540	talk	1.0																			research relate datum	1																		
+1541	za055154	1.0																			deny	1																		
+1542	middlesex	1.0																			want information collect	1																		
+1543	west	1.0																			cookie feature	1																		
+1544	____________________________________________________________________	1.0																			offer setting	1																		
+1545	interact	1.0																			example apple ios	1																		
+1546	key	1.0																			app information	1																		
+1547	children	1.0																			collection use	1																		
+1548	invite	1.0																			advertising id	1																		
+1549	import	1.0																			service e-mail	1																		
+1550	manually	1.0																			-urlto update amend	1																		
+1551	pepper	1.0																			informed	1																		
+1552	deals	1.0																			gdpr complaint	1																		
+1553	ec2a	1.0																			entitle resident	1																		
+1554	3hh	1.0																			business share	1																		
+1555	row	1.0																			business relationship	1																		
+1556	batemans	1.0																			precede calendar year	1																		
+1557	unit	1.0																			information disclosure	1																		
+1558	cheshire	1.0																			correct amend	1																		
+1559	wycliffe	1.0																			contact duolingo	1																		
+1560	wilmslow	1.0																			acknowledgement	1																		
+1561	water	1.0																			bbb eu privacy shield	1																		
+1562	5af	1.0																			duolingo change	1																		
+1563	sk9	1.0																			allow parent	1																		
+1564	youre	1.0																			datum privacy inquiry	1																		
+1565	beginning	1.0																			direct	1																		
+1566	lindgreens	1.0																			login setting	1																		
+1567	37561304	1.0																			exchange	1																		
+1568	language	1.0																			facebook google	1																		
+1569	benhavn	1.0																			network	1																		
+1570	2300	1.0																			flaregames	1																		
+1571	sor	1.0																			operation	1																		
+1572	subscription	1.0																			game app	1																		
+1573	elect	1.0																			retention obligation	1																		
+1574	subsequently	1.0																			flaregames comply	1																		
+1575	restaurants	1.0																			like cookie	1																		
+1576	finchley	1.0																			internet browser	1																		
+1577	59	1.0																			store cookie	1																		
+1578	road	1.0																			condition stipulate	1																		
+1579	n2	1.0																			time delete	1																		
+1580	switch	1.0																			service offer	1																		
+1581	27	1.0																			information society	1																		
+1582	dtv	1.0																			datum disclose	1																		
+1583	z9156270	1.0																			datum conduct	1																		
+1584	z7207230	1.0																			brunnsgatan	1																		
+1585	fax	1.0																			stockholm sweden	1																		
+1586	lease	1.0																			request rectification erasure portability	1																		
+1587	distribute	1.0																			blocking	1																		
+1588	1998	1.0																			discuss	1																		
+1589	advise	1.0																			follow reason	1																		
+1590	emailthat	1.0																			exist	1																		
+1591	minor	1.0																			question express	1																		
+1592	22581	1.0																			gamegos	1																		
+1593	211	1.0																			balancing-of interest rule	1																		
+1594	sms	1.0																			contract performance	1																		
+1595	push	1.0																			user want	1																		
+1596	acquire	1.0																			gametion technologies pvt ltd	1																		
+1597	asset	1.0																			game forum	1																		
+1598	buyer	1.0																			username password email address	1																		
+1599	smethwick	1.0																			-emailbut note	1																		
+1600	1by	1.0																			eea resident	1																		
+1601	roebuck	1.0																			dpo centre	1																		
+1602	policythis	1.0																			erase datum	1																		
+1603	deliver	1.0																			controller service	1																		
+1604	parcel	1.0																			datum privacy authority	1																		
+1605	return	1.0																			complaint regard adherence	1																		
+1606	usif	1.0																			datum change	1																		
+1607	early	1.0																			gogogame	1																		
+1608	dpd	1.0																			source verify	1																		
+1609	postcode	1.0																			rectification update	1																		
+1610	pickup	1.0																			amendment	1																		
+1611	surcharge	1.0																			data exist	1																		
+1612	brexit	1.0																			company service	1																		
+1613	fuel	1.0																			question query	1																		
+1614	schedule	1.0																			deactivate java operation	1																		
+1615	familiarize	1.0																			sentence	1																		
+1616	moment	1.0																			contact e-mail address	1																		
+1617	jeopardize	1.0																			remove content	1																		
+1618	impractical	1.0																			google service base	1																		
+1619	privacyto	1.0																			schiphol-rijk	1																		
+1620	apec	1.0																			beechavenue	1																		
+1621	apples	1.0																			circumstance apply	1																		
+1622	prp	1.0																			update policy	1																		
+1623	secure	1.0																			grab	1																		
+1624	cbpr	1.0																			data privacy officer	1																		
+1625	certification	1.0																			accessor request deletion	1																		
+1626	guideline	1.0																			applicationsor	1																		
+1627	companywide	1.0																			corrector update	1																		
+1628	region	1.0																			restrict processingof	1																		
+1629	triage	1.0																			request portabilityof	1																		
+1630	conjunction	1.0																			huuuges case cthe	1																		
+1631	planetart	1.0																			protection authority	1																		
+1632	calabasas	1.0																			president	1																		
+1633	91302	1.0																			office ofdata protection	1																		
+1634	datainspektionen	1.0																			matter relate	1																		
+1635	swedish	1.0																			huuugegroup	1																		
+1636	anonymise	1.0																			data protection issue	1																		
+1637	credit	1.0																			huuuge games sp	1																		
+1638	audit	1.0																			reach huuuges	1																		
+1639	accounting	1.0																			privacy policy change	1																		
+1640	fraud	1.0																			-email- notification	1																		
+1641	enjoy	1.0																			reflect change	1																		
+1642	45	1.0																			information practice	1																		
+1643	18th	1.0																			access restrict	1																		
+1644	10011	1.0																			mopub service	1																		
+1645	authenticate	1.0																			datum mopub collect	1																		
+1646	rate	1.0																			advertising demand partner	1																		
+1647																					publisher	1																		
+1648																					advertising demand portal	1																		
+1649																					request account deletion	1																		
+1650																					twitter international companyattn	1																		
+1651																					d02 ax07 ireland	1																		
+1652																					twitter international companys lead	1																		
+1653																					subsidiary account holder	1																		
+1654																					family plan	1																		
+1655																					account holder	1																		
+1656																					cancel email	1																		
+1657																					material	1																		
+1658																					post content	1																		
+1659																					identify	1																		
+1660																					eea register agent question comment	1																		
+1661																					reach headspace customer support	1																		
+1662																					tricor suite 4th floor	1																		
+1663																					mark lane london	1																		
+1664																					tricor	1																		
+1665																					7qr	1																		
+1666																					registered agent	1																		
+1667																					-emailin order	1																		
+1668																					member state law	1																		
+1669																					information society service	1																		
+1670																					cease processing	1																		
+1671																					lawfulness	1																		
+1672																					complaint saygames	1																		
+1673																					saygames llc address	1																		
+1674																					obligation place	1																		
+1675																					itv	1																		
+1676																					activity set	1																		
+1677																					service-specific privacy notice	1																		
+1678																					registered email address	1																		
+1679																					itv group company	1																		
+1680																					addressable platform limited	1																		
+1681																					britbox	1																		
+1682																					ico website	1																		
+1683																					register office	1																		
+1684																					holborn london ec1n 2ae	1																		
+1685																					waterhouse square	1																		
+1686																					itv rights limited	1																		
+1687																					britain	1																		
+1688																					got talent	1																		
+1689																					itv consumer limited	1																		
+1690																					fremantle media limited	1																		
+1691																					programme act	1																		
+1692																					producer	1																		
+1693																					vat registration number gb	1																		
+1694																					privacy query	1																		
+1695																					paris	1																		
+1696																					faubourg saint-denis	1																		
+1697																					hydrane sas	1																		
+1698																					data processing concern	1																		
+1699																					contact homa	1																		
+1700																					homa hold	1																		
+1701																					provide homa	1																		
+1702																					storage deletion	1																		
+1703																					set instruction regard	1																		
+1704																					death	1																		
+1705																					close publishing	1																		
+1706																					search hit enter	1																		
+1707																					esc	1																		
+1708																					faubourg saint-denis paris france	1																		
+1709																					game support	1																		
+1710																					condition twitter facebook linkedin search	1																		
+1711																					rue	1																		
+1712																					use cookie	1																		
+1713																					business relate enquiry	1																		
+1714																					experience	1																		
+1715																					disable cookie	1																		
+1716																					calendar year	1																		
+1717																					residentsonce	1																		
+1718																					obtain information	1																		
+1719																					marketing use	1																		
+1720																					recommend	1																		
+1721																					tiktok inc	1																		
+1722																					tiktok legal department	1																		
+1723																					venice blvd suite	1																		
+1724																					october 2019welcome	1																		
+1725																					tiktok	1																		
+1726																					usaemail address	1																		
+1727																					bytedance uk limited aviation house	1																		
+1728																					kingsway holborn london wc2b	1																		
+1729																					upload content	1																		
+1730																					privacy policy click	1																		
+1731																					rightsyou	1																		
+1732																					confirmation	1																		
+1733																					examine	1																		
+1734																					complaintsin	1																		
+1735																					email protect	1																		
+1736																					request ironhide	1																		
+1737																					browser add-on	1																		
+1738																					datum use	1																		
+1739																					flash cookie	1																		
+1740																					add-on	1																		
+1741																					web site	1																		
+1742																					manufacturer	1																		
+1743																					case update	1																		
+1744																					reference	1																		
+1745																					shopping list	1																		
+1746																					access example	1																		
+1747																					gift registry	1																		
+1748																					recommendation	1																		
+1749																					include credit card information	1																		
+1750																					advertising preference address book	1																		
+1751																					include product availability alerts delivers	1																		
+1752																					baby	1																		
+1753																					improve	1																		
+1754																					gift card balance	1																		
+1755																					include wish lists	1																		
+1756																					include recommended	1																		
+1757																					certificate	1																		
+1758																					england	1																		
+1759																					company registered	1																		
+1760																					committed	1																		
+1761																					process contact information	1																		
+1762																					support request	1																		
+1763																					-emailin accordance	1																		
+1764																					support centre	1																		
+1765																					use agree	1																		
+1766																					pursue	1																		
+1767																					system provider	1																		
+1768																					talk	1																		
+1769																					za055154	1																		
+1770																					data protection team	1																		
+1771																					fireproof studios ltd	1																		
+1772																					question feel	1																		
+1773																					communication preference	1																		
+1774																					correct erase restrict object	1																		
+1775																					interact	1																		
+1776																					sega learn	1																		
+1777																					operation sega	1																		
+1778																					import	1																		
+1779																					enter e-mail address	1																		
+1780																					playdemic	1																		
+1781																					invite	1																		
+1782																					join	1																		
+1783																					information playdemic receive	1																		
+1784																					information information	1																		
+1785																					information playdemic	1																		
+1786																					e-mail preference	1																		
+1787																					e-mail preference page	1																		
+1788																					access user	1																		
+1789																					pepper deals ltd unit	1																		
+1790																					batemans row london	1																		
+1791																					3hh	1																		
+1792																					detail regard	1																		
+1793																					beginning	1																		
+1794																					remove permission	1																		
+1795																					facebook	1																		
+1796																					data access	1																		
+1797																					data retention	1																		
+1798																					tgtg platform	1																		
+1799																					support section	1																		
+1800																					country website	1																		
+1801																					data processing activity carry	1																		
+1802																					tgtg	1																		
+1803																					language website	1																		
+1804																					lindgreens	1																		
+1805																					mail address	1																		
+1806																					delete location information	1																		
+1807																					address list	1																		
+1808																					opt-out instruction	1																		
+1809																					subscription feature	1																		
+1810																					opt-in	1																		
+1811																					elect	1																		
+1812																					receive marketing communication	1																		
+1813																					website link list	1																		
+1814																					app process	1																		
+1815																					freeview mobile app	1																		
+1816																					switch	1																		
+1817																					uk information commissioners office	1																		
+1818																					follow detail	1																		
+1819																					legal department freeview 2nd floor	1																		
+1820																					dtv services ltd	1																		
+1821																					registration number z9156270 act	1																		
+1822																					digital uk limited	1																		
+1823																					email phone fax	1																		
+1824																					sell distribute	1																		
+1825																					lease	1																		
+1826																					website look	1																		
+1827																					box	1																		
+1828																					request detail	1																		
+1829																					data protection act	1																		
+1830																					request picsart	1																		
+1831																					update edit	1																		
+1832																					privacy preference	1																		
+1833																					picsart service	1																		
+1834																					account compromise	1																		
+1835																					advise	1																		
+1836																					misuse	1																		
+1837																					minor	1																		
+1838																					professions code section	1																		
+1839																					email -emailor contact	1																		
+1840																					california business	1																		
+1841																					registered user	1																		
+1842																					email sms push notification	1																		
+1843																					buy	1																		
+1844																					asset	1																		
+1845																					sell	1																		
+1846																					seller	1																		
+1847																					buyer	1																		
+1848																					issue concern	1																		
+1849																					re-deliver	1																		
+1850																					delivery point	1																		
+1851																					parcel	1																		
+1852																					return	1																		
+1853																					deliver	1																		
+1854																					dpd	1																		
+1855																					conditions privacy	1																		
+1856																					uk delivery	1																		
+1857																					cookie policy phishing data protection	1																		
+1858																					postcode affect	1																		
+1859																					dpd terms	1																		
+1860																					gdpr sitemap fuel surcharge	1																		
+1861																					services uk europe	1																		
+1862																					familiarize	1																		
+1863																					moment	1																		
+1864																					process request	1																		
+1865																					jeopardize	1																		
+1866																					security guideline	1																		
+1867																					datum use concern regard	1																		
+1868																					communicate	1																		
+1869																					prp certification	1																		
+1870																					apec cbpr	1																		
+1871																					apple employee	1																		
+1872																					dispute resolution	1																		
+1873																					commitment	1																		
+1874																					apples privacy policy	1																		
+1875																					european data protection officer	1																		
+1876																					enforce privacy safeguard	1																		
+1877																					information receive	1																		
+1878																					triage	1																		
+1879																					team	1																		
+1880																					apple support number	1																		
+1881																					time refer	1																		
+1882																					reply receive	1																		
+1883																					conjunction	1																		
+1884																					above-mention right	1																		
+1885																					planetart llc	1																		
+1886																					include profiling base	1																		
+1887																					processing serve	1																		
+1888																					marketing relate purpose	1																		
+1889																					customer care department use	1																		
+1890																					contact customer support	1																		
+1891																					-emailor assistance	1																		
+1892																					authority ico	1																		
+1893																					term use	1																		
+1894																					clarification	1																		
+1895																					follow setting	1																		
+1896																					spotify use	1																		
+1897																					ease	1																		
+1898																					data protection officer use	1																		
+1899																					swedish data protection authority	1																		
+1900																					datainspektionen	1																		
+1901																					issue relate	1																		
+1902																					credit	1																		
+1903																					datum include situation	1																		
+1904																					anonymise	1																		
+1905																					tax audit	1																		
+1906																					accounting obligation	1																		
+1907																					period require	1																		
+1908																					spotify	1																		
+1909																					control section	1																		
+1910																					request exercise	1																		
+1911																					age limit	1																		
+1912																					new york ny	1																		
+1913																					enjoy spotify	1																		
+1914																					street floor	1																		
+1915																					contact customer service	1																		
+1916																					information cookie	1																		
+1917																					authenticate	1																		
+1918																					safety	1																		
+1919																					netflix account	1																		
+1920																					step vary	1																		
+1921																					netflix setting	1																		
+1922																					website choose	1																		
+1923																					note deactivation	1																		
+1924																					remove access	1																		
+1925																					account include	1																		
+1926																					rate	1																		
+1927																					related information	1																		
+1928																					netflix payment information	1																		

--- a/event_extraction/test_somajo.py
+++ b/event_extraction/test_somajo.py
@@ -1,0 +1,54 @@
+from somajo import SoMaJo
+
+tokenizer = SoMaJo("en_PTB", split_sentences=False)
+
+# def detokenize(tokens):
+#     out = []
+#     for token in tokens:
+#         if token.original_spelling is not None:
+#             out.append(token.original_spelling)
+#         else:
+#             out.append(token.text)
+#         if token.space_after:
+#             out.append(" ")
+#     return "".join(out)
+
+
+def somajo_remove_url(text):
+    """
+    A customized function to remove e-mails which have whitespaces
+    and URLs which were apparently not cleaned from the corpus.
+    """
+    out = []
+    text_as_list = list()
+    text_as_list.append(text)
+    tokenized_text = tokenizer.tokenize_text(text_as_list)
+    for dummy_tokenized_text in tokenized_text:
+        # return([detokenize(bla) for bla in tokenized_text][0])
+        for token in dummy_tokenized_text:
+            if token.token_class == "URL":
+                out.append("-URL-")
+            elif token.original_spelling is not None:
+                out.append(token.original_spelling)
+            else:
+                out.append(token.text)
+            if token.space_after:
+                out.append(" ")
+    return "".join(out)
+
+
+list_of_texts = ["For more information on which authority to contact , please email us here support @ infinitygames.io .",
+              "For further clarification of the terms used in this Policy please visit our Privacy Center on spotify.com",
+              "If you want to contact us about our services , you can find more details at www.itv.com/contactus",
+              "Platonova 20b/112-1 E-mail : info @ saygames.by If you wish to make a complaint over the processing of your personal data , you have the right to lodge a complaint to the relevant supervisory authority"]
+
+for text in list_of_texts:
+    # text_as_list = list()
+    # text_as_list.append(text)
+    # tokenized_text = tokenizer.tokenize_text(text_as_list)
+    # for bla in tokenized_text:
+        # for token in bla:
+        #    print("{}\t{}\t{}\t{}".format(token.text, token.token_class, token.extra_info, token.original_spelling))
+    # print([detokenize(bla) for bla in tokenized_text][0])
+    print(somajo_remove_url(text))
+    print()


### PR DESCRIPTION
This commit includes enhancements such as finding emails and URLs in the corpus which had originally not been replaced with "-URL-" and "-Email-" respectively. 